### PR TITLE
Revert mvn group-id to io.brooklyn.networking

### DIFF
--- a/cloudstack/pom.xml
+++ b/cloudstack/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <groupId>org.apache.brooklyn.networking</groupId>
+        <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
         <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <groupId>org.apache.brooklyn.networking</groupId>
+        <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
         <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.apache.brooklyn.networking</groupId>
+    <groupId>io.brooklyn.networking</groupId>
     <artifactId>brooklyn-networking-parent</artifactId>
     <packaging>pom</packaging>
 

--- a/portforwarding/pom.xml
+++ b/portforwarding/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <groupId>org.apache.brooklyn.networking</groupId>
+        <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
         <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <parent>
-        <groupId>org.apache.brooklyn.networking</groupId>
+        <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
         <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>


### PR DESCRIPTION
- We can’t change the maven group id of this repo to 
  org.apache.brooklyn.networking because it is not an apache project.
  Apache own that domain, so we can’t push to sonatype with it.
