### PR TITLE
Version 0.7.0-M2-incubating

### DIFF
--- a/cloudstack/pom.xml
+++ b/cloudstack/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-M2-incubating</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-M2-incubating</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,12 @@
     <parent>
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-downstream-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-M2-incubating</version>  <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>
-        <brooklyn.version>0.7.0-SNAPSHOT</brooklyn.version> <!--  BROOKLYN_VERSION -->
+        <brooklyn.version>0.7.0-M2-incubating</brooklyn.version> <!--  BROOKLYN_VERSION -->
         <jclouds.groupId>org.apache.jclouds</jclouds.groupId>
     </properties>
 

--- a/portforwarding/pom.xml
+++ b/portforwarding/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-M2-incubating</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-M2-incubating</version> <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Change the version to reflext the upcoming Brooklyn 0.7.0-M2-incubating release. This should be merged into a release branch and tagged appropriately.