### PR TITLE
add remove NAT rules

### DIFF
--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatPredicates.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatPredicates.java
@@ -4,6 +4,8 @@ import com.google.common.base.Predicate;
 import com.vmware.vcloud.api.rest.schema.GatewayNatRuleType;
 import com.vmware.vcloud.api.rest.schema.NatRuleType;
 
+import brooklyn.util.net.Protocol;
+
 public class NatPredicates {
 
     public static Predicate<NatRuleType> translatedTargetEquals(String ip, int port) {
@@ -43,4 +45,22 @@ public class NatPredicates {
             return (rule != null) && ip.equals(rule.getOriginalIp()) && Integer.toString(port).equals(rule.getOriginalPort()); 
         }
     }
+
+    public static Predicate<? super NatRuleType> protocolMatches(Protocol protocol) {
+        return new ProtocolEquals(protocol);
+    }
+
+    protected static class ProtocolEquals implements Predicate<NatRuleType> {
+        private final Protocol protocol;
+
+        public ProtocolEquals(Protocol protocol) {
+            this.protocol = protocol;
+        }
+        @Override
+        public boolean apply(NatRuleType input) {
+            GatewayNatRuleType rule = (input == null) ? null : input.getGatewayNatRule();
+            return (rule != null) && protocol.toString().equalsIgnoreCase(rule.getProtocol());
+        }
+    }
+
 }

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/PortForwarderVcloudDirector.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/PortForwarderVcloudDirector.java
@@ -15,8 +15,6 @@
  */
 package brooklyn.networking.vclouddirector;
 
-import static com.google.common.base.Objects.firstNonNull;
-
 import java.util.List;
 import java.util.Map;
 
@@ -30,17 +28,19 @@ import org.slf4j.LoggerFactory;
 import brooklyn.config.ConfigKey;
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.ConfigKeys;
+import brooklyn.entity.basic.EntityAndAttribute;
 import brooklyn.location.Location;
 import brooklyn.location.MachineLocation;
 import brooklyn.location.PortRange;
 import brooklyn.location.access.PortForwardManager;
+import brooklyn.location.basic.Machines;
 import brooklyn.location.basic.PortRanges;
 import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.location.jclouds.JcloudsUtil;
 import brooklyn.management.ManagementContext;
 import brooklyn.networking.subnet.PortForwarder;
 import brooklyn.networking.subnet.SubnetTier;
-import brooklyn.networking.vclouddirector.NatService.OpenPortForwardingConfig;
+import brooklyn.networking.vclouddirector.NatService.PortForwardingConfig;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.net.HasNetworkAddresses;
 import brooklyn.util.net.Protocol;
@@ -48,6 +48,7 @@ import brooklyn.util.text.Strings;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
@@ -174,10 +175,8 @@ public class PortForwarderVcloudDirector implements PortForwarder {
         // TODO should associate ip:port with PortForwardManager; but that takes location param
         //      getPortForwardManager().associate(publicIp, publicPort, targetVm, targetPort);
         // TODO Could check old mapping, and re-use that public port
-        // TODO Given the VM, could look up to find the network (rather than hard-coding!)
         // TODO Pass cidr in vcloud-director call
         PortForwardManager pfw = getPortForwardManager();
-        String networkId = firstNonNull(subnetTier.getConfig(NETWORK_ID), getNetworkIdFromNetworkName(subnetTier.getConfig(NETWORK_NAME)));
         String publicIp = subnetTier.getConfig(NETWORK_PUBLIC_IP);
 
         int publicPort;
@@ -188,18 +187,54 @@ public class PortForwarderVcloudDirector implements PortForwarder {
         }
         
         try {
-            HostAndPort result = getService().openPortForwarding(new OpenPortForwardingConfig()
-                    .networkId(networkId)
+            HostAndPort result = getService().openPortForwarding(new PortForwardingConfig()
                     .publicIp(publicIp)
                     .protocol(Protocol.TCP)
                     .target(target)
                     .publicPort(publicPort));
             LOG.debug("Enabled port-forwarding for {}, via {}, on ", new Object[] {target, result, subnetTier});
             return result;
+        } catch (IllegalStateException e) {
+            throw Throwables.propagate(e);
         } catch (Exception e) {
             LOG.error("Failed creating port forwarding rule on "+this+" to "+target, e);
             // it might already be created, so don't crash and burn too hard!
             return HostAndPort.fromParts(publicIp, publicPort);
+        }
+    }
+
+    public void closePortForwarding(EntityAndAttribute<Integer> privatePort, Optional<Integer> optionalPublicPort) {
+        Entity entity = privatePort.getEntity();
+        Integer targetPort = privatePort.getValue();
+        MachineLocation machine = Machines.findUniqueMachineLocation(entity.getLocations()).get();
+        String targetIp = Iterables.getFirst(Iterables.concat(machine.getPrivateAddresses(), machine.getPublicAddresses()), null);
+        if (targetIp == null) {
+            throw new IllegalStateException("Failed to close port-forwarding for machine " + machine + " because its location has no target ip: " + machine);
+        }
+        HostAndPort target = HostAndPort.fromParts(targetIp, targetPort);
+
+        PortForwardManager pfw = getPortForwardManager();
+        String publicIp = subnetTier.getConfig(NETWORK_PUBLIC_IP);
+
+        int publicPort;
+        if (optionalPublicPort.isPresent()) {
+            publicPort = optionalPublicPort.get();
+        } else {
+            publicPort = pfw.acquirePublicPort(publicIp);
+        }
+
+        try {
+            HostAndPort result = getService().closePortForwarding(new PortForwardingConfig()
+                    .publicIp(publicIp)
+                    .protocol(Protocol.TCP)
+                    .target(target)
+                    .publicPort(publicPort));
+            LOG.debug("Disabled port-forwarding for {}, via {}, on ", new Object[]{target, result, subnetTier});
+        } catch (IllegalStateException e) {
+            throw Throwables.propagate(e);
+        } catch (Exception e) {
+            LOG.error("Failed disabling port forwarding rule on " + this + " to " + target, e);
+            // it might not be created, so don't crash and burn too hard!
         }
     }
 


### PR DESCRIPTION
add support for closePortForwarding for PortForwarderVcloudDirector
refactor VcloudDirectorSubnetTierLiveTest to create a VM for the test
modify NatService: networkId is no more required by the user
