### PR TITLE
Fix nat-service

### DIFF
--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/DockerPortForwarder.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/DockerPortForwarder.java
@@ -150,7 +150,7 @@ public class DockerPortForwarder implements PortForwarder {
     public HostAndPort openPortForwarding(HasNetworkAddresses targetMachine, int targetPort, Optional<Integer> optionalPublicPort,
             Protocol protocol, Cidr accessingCidr) {
 
-    	String targetIp = Iterables.getFirst(Iterables.concat(targetMachine.getPrivateAddresses(), targetMachine.getPublicAddresses()), null);
+        String targetIp = Iterables.getFirst(Iterables.concat(targetMachine.getPrivateAddresses(), targetMachine.getPublicAddresses()), null);
         if (targetIp==null) {
             throw new IllegalStateException("Failed to open port-forwarding for machine "+targetMachine+" because its" +
                     " location has no target ip: "+targetMachine);

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/NoopPortForwarder.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/NoopPortForwarder.java
@@ -91,16 +91,16 @@ public class NoopPortForwarder implements PortForwarder {
     @Override
     public HostAndPort openPortForwarding(HasNetworkAddresses targetMachine, int targetPort, Optional<Integer> optionalPublicPort,
             Protocol protocol, Cidr accessingCidr) {
-    	// Prefer hostname (because within AWS that resolves correctly to private ip, whereas public ip is not reachable)
+        // Prefer hostname (because within AWS that resolves correctly to private ip, whereas public ip is not reachable)
         String targetIp = null;
         String hostname = targetMachine.getHostname();
         if (hostname != null) {
-        	try {
-        		InetAddress.getByName(hostname).getAddress();
-        		targetIp = hostname;
-        	} catch (UnknownHostException e) {
+            try {
+                InetAddress.getByName(hostname).getAddress();
+                targetIp = hostname;
+            } catch (UnknownHostException e) {
                 if (log.isDebugEnabled()) log.debug("Unable to resolve host "+hostname+"; falling back to IPs");
-        	}
+            }
         }
         if (targetIp == null) {
             Iterable<String> addresses = Iterables.concat(targetMachine.getPublicAddresses(), targetMachine.getPrivateAddresses());

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/PortForwarderIptables.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/PortForwarderIptables.java
@@ -133,7 +133,7 @@ public class PortForwarderIptables implements PortForwarder {
     public HostAndPort openPortForwarding(HasNetworkAddresses targetMachine, int targetPort, Optional<Integer> optionalPublicPort,
             Protocol protocol, Cidr accessingCidr) {
 
-    	String targetIp = Iterables.getFirst(Iterables.concat(targetMachine.getPrivateAddresses(), targetMachine.getPublicAddresses()), null);
+        String targetIp = Iterables.getFirst(Iterables.concat(targetMachine.getPrivateAddresses(), targetMachine.getPublicAddresses()), null);
         if (targetIp==null) {
             throw new IllegalStateException("Failed to open port-forarding for machine "+targetMachine+" because its location has no target ip: "+targetMachine);
         }

--- a/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTierImpl.java
+++ b/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTierImpl.java
@@ -168,21 +168,21 @@ public class SubnetTierImpl extends AbstractEntity implements SubnetTier {
 
         @Override
         public HostAndPort openPortForwarding(final NodeMetadata node, int targetPort, Optional<Integer> optionalPublicPort, Protocol protocol, Cidr accessingCidr) {
-        	HasNetworkAddresses hasNetworkAddresses = new HasNetworkAddresses() {
-				@Override public String getHostname() {
-					return node.getHostname();
-				}
-				@Override public Set<String> getPublicAddresses() {
-					return node.getPublicAddresses();
-				}
-				@Override public Set<String> getPrivateAddresses() {
-					return node.getPrivateAddresses();
-				}
-				@Override
-				public String toString() {
-					return node.toString();
-				}
-        	};
+            HasNetworkAddresses hasNetworkAddresses = new HasNetworkAddresses() {
+                @Override public String getHostname() {
+                    return node.getHostname();
+                }
+                @Override public Set<String> getPublicAddresses() {
+                    return node.getPublicAddresses();
+                }
+                @Override public Set<String> getPrivateAddresses() {
+                    return node.getPrivateAddresses();
+                }
+                @Override
+                public String toString() {
+                    return node.toString();
+                }
+            };
             HostAndPort result = pf.openPortForwarding(
                     hasNetworkAddresses,
                     node.getLoginPort(),

--- a/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
@@ -177,7 +177,7 @@ public class SubnetTierTest {
         }
         @Override public HostAndPort openPortForwarding(HasNetworkAddresses targetMachine, int targetPort, Optional<Integer> optionalPublicPort,
                 Protocol protocol, Cidr accessingCidr) {
-        	String targetIp = Iterables.getFirst(Iterables.concat(targetMachine.getPrivateAddresses(), targetMachine.getPublicAddresses()), null);
+            String targetIp = Iterables.getFirst(Iterables.concat(targetMachine.getPrivateAddresses(), targetMachine.getPublicAddresses()), null);
             HostAndPort targetSide = HostAndPort.fromParts(targetIp, targetPort);
             return checkNotNull(mapping.get(targetSide), "no mapping for %s", targetSide);
         }

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/CustomSSLSocketFactory.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/CustomSSLSocketFactory.java
@@ -28,41 +28,41 @@ import org.apache.http.conn.ssl.SSLSocketFactory;
 
 public class CustomSSLSocketFactory {
 
-	private CustomSSLSocketFactory() {
-	}
+    private CustomSSLSocketFactory() {
+    }
 
-	public static SSLSocketFactory getInstance()
-			throws NoSuchAlgorithmException, KeyStoreException,
-			CertificateException, KeyManagementException, IOException {
+    public static SSLSocketFactory getInstance()
+            throws NoSuchAlgorithmException, KeyStoreException,
+            CertificateException, KeyManagementException, IOException {
 
-		TrustManagerFactory trustManagerFactory = TrustManagerFactory
-				.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-		KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-		try{
-			String trustStore = System.getProperty("javax.net.ssl.trustStore");
-			String trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
-			if(trustStore == null || trustStorePassword == null){
-				throw new IOException("javax.net.ssl.trustStore/javax.net.ssl.trustStorePassword property - not set");
-			}
-			FileInputStream keystoreStream = new FileInputStream(trustStore);
-			try{
-				keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-				keystore.load(keystoreStream, trustStorePassword.toCharArray());
-			} finally{
-				keystoreStream.close();
-			}
-		} catch(FileNotFoundException e){
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		trustManagerFactory.init(keystore);
-		TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-		SSLContext sslContext = SSLContext.getInstance("TLS");
-		sslContext.init(null, trustManagers, null);
-		SSLContext.setDefault(sslContext);
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory
+                .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+        try{
+            String trustStore = System.getProperty("javax.net.ssl.trustStore");
+            String trustStorePassword = System.getProperty("javax.net.ssl.trustStorePassword");
+            if(trustStore == null || trustStorePassword == null){
+                throw new IOException("javax.net.ssl.trustStore/javax.net.ssl.trustStorePassword property - not set");
+            }
+            FileInputStream keystoreStream = new FileInputStream(trustStore);
+            try{
+                keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+                keystore.load(keystoreStream, trustStorePassword.toCharArray());
+            } finally{
+                keystoreStream.close();
+            }
+        } catch(FileNotFoundException e){
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        trustManagerFactory.init(keystore);
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, trustManagers, null);
+        SSLContext.setDefault(sslContext);
 
-		return new SSLSocketFactory(sslContext,
-				SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-	}
+        return new SSLSocketFactory(sslContext,
+                SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+    }
 }

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/FakeSSLSocketFactory.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/FakeSSLSocketFactory.java
@@ -23,18 +23,18 @@ import org.apache.http.conn.ssl.TrustStrategy;
 
 public class FakeSSLSocketFactory {
 
-	private FakeSSLSocketFactory() {
-	}
+    private FakeSSLSocketFactory() {
+    }
 
-	public static SSLSocketFactory getInstance() throws KeyManagementException,
-			UnrecoverableKeyException, NoSuchAlgorithmException,
-			KeyStoreException {
-		return new SSLSocketFactory(new TrustStrategy() {
-			public boolean isTrusted(final X509Certificate[] chain,
-					final String auth) throws CertificateException {
-				return true;
-			}
+    public static SSLSocketFactory getInstance() throws KeyManagementException,
+            UnrecoverableKeyException, NoSuchAlgorithmException,
+            KeyStoreException {
+        return new SSLSocketFactory(new TrustStrategy() {
+            public boolean isTrusted(final X509Certificate[] chain,
+                    final String auth) throws CertificateException {
+                return true;
+            }
 
-		}, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-	}
+        }, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+    }
 }

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
@@ -66,13 +66,13 @@ import com.vmware.vcloud.sdk.constants.query.QueryReferenceType;
 @Beta
 public class NatService {
 
-	private static final Logger LOG = LoggerFactory.getLogger(NatService.class);
-	
+    private static final Logger LOG = LoggerFactory.getLogger(NatService.class);
+    
     private static final List<Version> VCLOUD_VERSIONS = ImmutableList.of(Version.V5_5, Version.V5_1, Version.V1_5);
 
-	public static Builder builder() {
-		return new Builder();
-	}
+    public static Builder builder() {
+        return new Builder();
+    }
 
     public static class Builder {
         private String identity;
@@ -84,19 +84,19 @@ public class NatService {
         private Object mutex = new Object();
         
         public Builder identity(String val) {
-        	this.identity = val; return this;
+            this.identity = val; return this;
         }
         public Builder credential(String val) {
-        	this.credential = val; return this;
+            this.credential = val; return this;
         }
         public Builder endpoint(String val) {
-        	this.endpoint = checkNotNull(val, "endpoint"); return this;
+            this.endpoint = checkNotNull(val, "endpoint"); return this;
         }
         public Builder trustStore(String val) {
-        	this.trustStore = val; return this;
+            this.trustStore = val; return this;
         }
         public Builder trustStorePassword(String val) {
-        	this.trustStorePassword = val; return this;
+            this.trustStorePassword = val; return this;
         }
         public Builder logLevel(java.util.logging.Level val) {
             this.logLevel = val; return this;
@@ -104,9 +104,9 @@ public class NatService {
         public Builder mutex(Object mutex) {
             this.mutex = checkNotNull(mutex, "mutex"); return this;
         }
-    	public NatService build() {
-    		return new NatService(this);
-    	}
+        public NatService build() {
+            return new NatService(this);
+        }
     }
     
     public static class Delta {
@@ -137,7 +137,7 @@ public class NatService {
         }
     }
     
-	private final String baseUrl; // e.g. "https://p5v1-vcd.vchs.vmware.com:443";
+    private final String baseUrl; // e.g. "https://p5v1-vcd.vchs.vmware.com:443";
     private final String credential;
     private final String identity;
     private final String trustStore;
@@ -463,14 +463,14 @@ public class NatService {
 
     // FIXME Don't set sysprop as could affect all other activities of the JVM!
     protected VcloudClient newVcloudClient(String endpoint, String identity, String credential, String trustStore, String trustStorePassword, Level logLevel) {
-    	try {
-    	    if (logLevel != null) {
-    	        // Logging is extremely verbose at INFO - it logs in full every http request/response (including payload).
-    	        // Consider setting this to WARN; leaving as default is not explicitly set
-    	        VcloudClient.setLogLevel(logLevel);
-    	    }
-    	    
-    		// Client login
+        try {
+            if (logLevel != null) {
+                // Logging is extremely verbose at INFO - it logs in full every http request/response (including payload).
+                // Consider setting this to WARN; leaving as default is not explicitly set
+                VcloudClient.setLogLevel(logLevel);
+            }
+            
+            // Client login
             VcloudClient vcloudClient = null;
             boolean versionFound = false;
             for (Version version : VCLOUD_VERSIONS) {
@@ -490,19 +490,19 @@ public class NatService {
             }
             
             // Performing Certificate Validation
-			if (trustStore != null) {
-				System.setProperty("javax.net.ssl.trustStore", trustStore);
-				System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
-				vcloudClient.registerScheme("https", 443, CustomSSLSocketFactory.getInstance());
+            if (trustStore != null) {
+                System.setProperty("javax.net.ssl.trustStore", trustStore);
+                System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
+                vcloudClient.registerScheme("https", 443, CustomSSLSocketFactory.getInstance());
 
-			} else {
+            } else {
                 LOG.warn("Ignoring the Certificate Validation using FakeSSLSocketFactory");
                 vcloudClient.registerScheme("https", 443, FakeSSLSocketFactory.getInstance());
-			}
-			return vcloudClient;
-    	} catch (Exception e) {
-    		throw Exceptions.propagate(e);
-    	}
+            }
+            return vcloudClient;
+        } catch (Exception e) {
+            throw Exceptions.propagate(e);
+        }
     }
 
     private GatewayNatRuleType generateGatewayNatRule(Protocol protocol, HostAndPort original,

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
@@ -3,11 +3,10 @@ package brooklyn.networking.vclouddirector;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.net.InetAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 
@@ -16,17 +15,17 @@ import javax.xml.bind.JAXBElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.guava.Maybe;
 import brooklyn.util.net.Protocol;
 
-import com.google.common.base.Objects;
 import com.google.common.annotations.Beta;
+import com.google.common.base.Objects;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.InetAddresses;
 import com.vmware.vcloud.api.rest.schema.GatewayFeaturesType;
@@ -82,21 +81,6 @@ public class NatService {
         private Level logLevel;
         private Object mutex = new Object();
         
-        public Builder location(JcloudsLocation val) {
-        	identity(val.getIdentity());
-        	credential(val.getCredential());
-        	endpoint(transformEndpoint(val.getEndpoint()));
-        	return this;
-        }
-        private String transformEndpoint(String val) {
-            // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api"
-            URI uri = URI.create(val);
-            try {
-                return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
-            } catch (URISyntaxException e) {
-                throw Exceptions.propagate(e);
-            } 
-        }
         public Builder identity(String val) {
         	this.identity = val; return this;
         }
@@ -123,6 +107,34 @@ public class NatService {
     	}
     }
     
+    public static class Delta {
+        private final List<PortForwardingConfig> toClose = Lists.newArrayList();
+        private final List<PortForwardingConfig> toOpen = Lists.newArrayList();
+        
+        public Delta() {
+        }
+        public Delta toOpen(Iterable<PortForwardingConfig> vals) {
+            Iterables.addAll(toOpen, vals); return this;
+        }
+        public Delta toClose(Iterable<PortForwardingConfig> vals) {
+            Iterables.addAll(toClose, vals); return this;
+        }
+        public void checkValid() {
+            for (PortForwardingConfig arg : toOpen) {
+                arg.checkValid();
+            }
+            for (PortForwardingConfig arg : toClose) {
+                arg.checkValid();
+            }
+        }
+        @Override public String toString() {
+            return Objects.toStringHelper(this).add("toOpen", toOpen).add("toClose", toClose).toString();
+        }
+        public boolean isEmpty() {
+            return toOpen.isEmpty() && toClose.isEmpty();
+        }
+    }
+    
 	private final VcloudClient client;
 	private final String baseUrl; // e.g. "https://p5v1-vcd.vchs.vmware.com:443";
 	private final Object mutex;
@@ -134,50 +146,46 @@ public class NatService {
     	mutex = checkNotNull(builder.mutex, "mutex");
     }
 
-    public static class PortForwardingConfig {
-    	private Protocol protocol;
-    	private HostAndPort target;
-    	private String networkId;
-    	private String publicIp;
-    	private Integer publicPort;
-    	
-    	public PortForwardingConfig protocol(Protocol val) {
-    		this.protocol = val; return this;
-    	}
-    	public PortForwardingConfig networkId(String val) {
-    		this.networkId = val; return this;
-    	}
-    	public PortForwardingConfig target(HostAndPort val) {
-    		this.target = val; return this;
-    	}
-    	public PortForwardingConfig publicIp(String val) {
-    		this.publicIp = val; return this;
-    	}
-    	public PortForwardingConfig publicPort(int val) {
-    		this.publicPort = val; return this;
-    	}
-        public void checkValid() {
-        	checkNotNull(protocol, "protocol");
-        	checkNotNull(target, "target");
-        	checkNotNull(publicIp, "publicIp");
-            checkNotNull(publicPort, publicPort);
+    public HostAndPort openPortForwarding(PortForwardingConfig args) throws VCloudException {
+        return openPortForwarding(ImmutableList.of(args)).get(0);
+    }
+    
+    public List<HostAndPort> openPortForwarding(Iterable<PortForwardingConfig> args) throws VCloudException {
+        updatePortForwarding(new Delta().toOpen(args));
+        
+        List<HostAndPort> result = Lists.newArrayList();
+        for (PortForwardingConfig arg : args) {
+            result.add(HostAndPort.fromParts(arg.publicIp, arg.publicPort));
         }
-    	@Override
-    	public String toString() {
-    		return Objects.toStringHelper(this).add("protocol", protocol).add("target", target).add("networkId", networkId)
-    				.add("publicIp", publicIp).add("publicPort", publicPort).toString();
-    	}
+        return result;
     }
 
-    public HostAndPort openPortForwarding(PortForwardingConfig args) throws VCloudException {
-        args.checkValid();
-        if (LOG.isDebugEnabled()) LOG.debug("Opening port forwarding at {}: {}", baseUrl, args);
+    public HostAndPort closePortForwarding(PortForwardingConfig args) throws VCloudException {
+        return closePortForwarding(ImmutableList.of(args)).get(0);
+    }
+    
+    public List<HostAndPort> closePortForwarding(Iterable<PortForwardingConfig> args) throws VCloudException {
+        updatePortForwarding(new Delta().toClose(args));
+        
+        List<HostAndPort> result = Lists.newArrayList();
+        for (PortForwardingConfig arg : args) {
+            result.add(HostAndPort.fromParts(arg.publicIp, arg.publicPort));
+        }
+        return result;
+    }
+    
+    public void updatePortForwarding(Delta delta) throws VCloudException {
+        if (delta.isEmpty()) return;
+        
+        delta.checkValid();
+        if (LOG.isDebugEnabled()) LOG.debug("Updating port forwarding at {}: {}", baseUrl, delta);
 
         int iteration = 0;
         do {
             iteration++;
             try {
-                return openPortForwardingImpl(args);
+                updatePortForwardingImpl(delta);
+                return;
             } catch (VCloudException e) {
                 // If the EdgeGateway is being reconfigured by someone else, then the update operation will fail.
                 // In that situation, retry (from the beginning - retrieve all rules again in case they are
@@ -186,8 +194,8 @@ public class NatService {
                 // 
                 // TODO Don't hard-code exception messages - dangerous for internationalisation etc.
                 if (e.toString().contains("is busy completing an operation")) {
-                    if (LOG.isDebugEnabled()) LOG.debug("Retrying after iteration {} failed (server busy), opening port forwarding at {}: {} - {}", 
-                            new Object[] {iteration, baseUrl, args, e});
+                    if (LOG.isDebugEnabled()) LOG.debug("Retrying after iteration {} failed (server busy), updating port forwarding at {}: {} - {}", 
+                            new Object[] {iteration, baseUrl, delta, e});
                 } else {
                     throw e;
                 }
@@ -195,15 +203,16 @@ public class NatService {
         } while (true);
     }
 
-    private HostAndPort openPortForwardingImpl(PortForwardingConfig args) throws VCloudException {
+    private void updatePortForwardingImpl(Delta delta) throws VCloudException {
         // Append DNAT rule to NAT service; retrieve the existing, modify it, and upload.
         // If instead we create new objects then risk those having different config - this is *not* a delta!
 
         synchronized (getMutex()) {
             EdgeGateway edgeGateway = getEdgeGateway();
             GatewayFeaturesType gatewayFeatures = getGatewayFeatures(edgeGateway);
+            NatServiceType natService = tryFindService(gatewayFeatures.getNetworkService(), NatServiceType.class).get();
 
-            // extract the external network attached to the EdgeGateway and its subnet partecipations to validate public IP
+            // extract the external network attached to the EdgeGateway and its subnet participations to validate public IP
             ReferenceType externalNetworkRef = null;
             List<SubnetParticipationType> subnetParticipations = Lists.newArrayList();
             for (GatewayInterfaceType gatewayInterfaceType : edgeGateway.getResource().getConfiguration().getGatewayInterfaces().getGatewayInterface()) {
@@ -212,116 +221,95 @@ public class NatService {
                     subnetParticipations.addAll(gatewayInterfaceType.getSubnetParticipation());
                 }
             }
-            checkPublicIp(args.publicIp, subnetParticipations);
+            Set<String> publicIps = Sets.newLinkedHashSet();
+            for (PortForwardingConfig arg : delta.toOpen) {
+                publicIps.add(arg.publicIp);
+            }
+            for (PortForwardingConfig arg : delta.toClose) {
+                publicIps.add(arg.publicIp);
+            }
+            checkPublicIps(publicIps, subnetParticipations);
             
-            // generate and add the new rule
-            GatewayNatRuleType gatewayNatRule = generateGatewayNatRule(
-                    args.protocol,
-                    HostAndPort.fromParts(args.publicIp, args.publicPort),
-                    args.target,
-                    externalNetworkRef);
-            NatRuleType dnatRule = generateDnatRule(true, gatewayNatRule);
-
-            NatServiceType natService = tryFindService(gatewayFeatures.getNetworkService(), NatServiceType.class).get();
-            natService.getNatRule().add(dnatRule);
+            // generate and add the new rules
+            for (PortForwardingConfig arg : delta.toOpen) {
+                GatewayNatRuleType gatewayNatRule = generateGatewayNatRule(
+                        arg.protocol,
+                        HostAndPort.fromParts(arg.publicIp, arg.publicPort),
+                        arg.target,
+                        externalNetworkRef);
+                NatRuleType dnatRule = generateDnatRule(true, gatewayNatRule);
+    
+                natService.getNatRule().add(dnatRule);
+            }
+            
+            // Remove the closed rules
+            for (PortForwardingConfig arg : delta.toClose) {
+                // TODO Could also match on networkId
+                Iterable<NatRuleType> filtered = Iterables.filter(natService.getNatRule(), Predicates.and(
+                        NatPredicates.protocolMatches(arg.protocol),
+                        NatPredicates.originalTargetEquals(arg.publicIp, arg.publicPort),
+                        NatPredicates.translatedTargetEquals(arg.target.getHostText(), arg.target.getPort())));
+                natService.getNatRule().removeAll(Lists.newArrayList(filtered));
+            }
 
             // Execute task (i.e. make the actual change, and wait for completion)
             Task task = edgeGateway.configureServices(gatewayFeatures);
-            waitForTask(task, "add dnat rule");
+            waitForTask(task, "update NAT rules");
 
-            // Confirm that the newly created rule exists,
-            // with the expected translated (i.e internal) and original (i.e. public) addresses,
-            // and without any conflicting DNAT rules already using that port.
+            // Confirm the updates have been applied.
             // Retrieves a new EdgeGateway instance, to ensure we're not just looking at our local copy.
             List<NatRuleType> rules = getNatRules(getEdgeGateway());
 
-            Iterable<NatRuleType> matches = Iterables.filter(rules, Predicates.and(
-                    NatPredicates.originalTargetEquals(args.publicIp, args.publicPort),
-                    NatPredicates.translatedTargetEquals(args.target.getHostText(), args.target.getPort())));
-
-            Iterable<NatRuleType> conflicts = Iterables.filter(rules, Predicates.and(
-                    NatPredicates.originalTargetEquals(args.publicIp, args.publicPort),
-                    Predicates.not(NatPredicates.translatedTargetEquals(args.target.getHostText(), args.target.getPort()))));
-
-            if (Iterables.isEmpty(matches)) {
-                throw new IllegalStateException(
-                        String.format("Gateway NAT Rules: cannot find translated %s and original %s:%s at %s",
-                                args.target, args.publicIp, args.publicPort, baseUrl));
-            } else if (Iterables.size(matches) > 1) {
-                LOG.warn(String.format("Gateway NAT Rules: %s duplicates for translated %s and original %s:%s at %s; continuing.",
-                        Iterables.size(matches), args.target, args.publicIp, args.publicPort, baseUrl));
-            }
-            if (Iterables.size(conflicts) > 0) {
-                throw new IllegalStateException(
-                        String.format("Gateway NAT Rules: original already assigned for translated %s and original %s:%s at %s",
-                                args.target, args.publicIp, args.publicPort, baseUrl));
-            }
-
-            return HostAndPort.fromParts(args.publicIp, args.publicPort);
-        }
-    }
-
-    public HostAndPort closePortForwarding(PortForwardingConfig args) throws VCloudException {
-        args.checkValid();
-        if (LOG.isDebugEnabled()) LOG.debug("Closing port forwarding at {}: {}", baseUrl, args);
-
-        int iteration = 0;
-        do {
-            iteration++;
-            try {
-                return closePortForwardingImpl(args);
-            } catch (VCloudException e) {
-                // If the EdgeGateway is being reconfigured by someone else, then the update operation will fail.
-                // In that situation, retry (from the beginning - retrieve all rules again in case they are
-                // different from last time). We've seen it regularly take 45 seconds to reconfigure the
-                // EdgeGateway (to add/remove a NAT rule), so be patient!
-                //
-                // TODO Don't hard-code exception messages - dangerous for internationalisation etc.
-                if (e.toString().contains("is busy completing an operation")) {
-                    if (LOG.isDebugEnabled()) LOG.debug("Retrying after iteration {} failed (server busy), opening port forwarding at {}: {} - {}",
-                            new Object[] {iteration, baseUrl, args, e});
-                } else {
-                    throw e;
+            // Confirm that the newly created rules exist,
+            // with the expected translated (i.e internal) and original (i.e. public) addresses,
+            // and without any conflicting DNAT rules already using that port.
+            for (PortForwardingConfig arg : delta.toOpen) {
+                Iterable<NatRuleType> matches = Iterables.filter(rules, Predicates.and(
+                        NatPredicates.originalTargetEquals(arg.publicIp, arg.publicPort),
+                        NatPredicates.translatedTargetEquals(arg.target.getHostText(), arg.target.getPort())));
+    
+                Iterable<NatRuleType> conflicts = Iterables.filter(rules, Predicates.and(
+                        NatPredicates.originalTargetEquals(arg.publicIp, arg.publicPort),
+                        Predicates.not(NatPredicates.translatedTargetEquals(arg.target.getHostText(), arg.target.getPort()))));
+    
+                if (Iterables.isEmpty(matches)) {
+                    throw new IllegalStateException(
+                            String.format("Gateway NAT Rules: cannot find translated %s and original %s:%s at %s",
+                                    arg.target, arg.publicIp, arg.publicPort, baseUrl));
+                } else if (Iterables.size(matches) > 1) {
+                    LOG.warn(String.format("Gateway NAT Rules: %s duplicates for translated %s and original %s:%s at %s; continuing.",
+                            Iterables.size(matches), arg.target, arg.publicIp, arg.publicPort, baseUrl));
+                }
+                if (Iterables.size(conflicts) > 0) {
+                    throw new IllegalStateException(
+                            String.format("Gateway NAT Rules: original already assigned for translated %s and original %s:%s at %s",
+                                    arg.target, arg.publicIp, arg.publicPort, baseUrl));
                 }
             }
-        } while (true);
-    }
-
-    private HostAndPort closePortForwardingImpl(PortForwardingConfig args) throws VCloudException {
-        // Remove DNAT rule from NAT service; retrieve the existing, modify it, and upload.
+            
+            // Confirm that deleted rules don't exist.
+            for (PortForwardingConfig arg : delta.toClose) {
+                Iterable<NatRuleType> matches = Iterables.filter(rules, Predicates.and(
+                        NatPredicates.protocolMatches(arg.protocol),
+                        NatPredicates.originalTargetEquals(arg.publicIp, arg.publicPort),
+                        NatPredicates.translatedTargetEquals(arg.target.getHostText(), arg.target.getPort())));
         
-        EdgeGateway edgeGateway = getEdgeGateway();
-        GatewayFeaturesType gatewayFeatures = getGatewayFeatures(edgeGateway);
-        NatServiceType natService = tryFindService(gatewayFeatures.getNetworkService(), NatServiceType.class).get();
-        List<NatRuleType> rules = getNatRules(edgeGateway);
-
-        // Modify the NAT rules to remove the matching rule
-        Iterable<NatRuleType> filtered = Iterables.filter(rules, Predicates.and(
-                NatPredicates.originalTargetEquals(args.publicIp, args.publicPort),
-                NatPredicates.translatedTargetEquals(args.target.getHostText(), args.target.getPort())));
-        natService.getNatRule().removeAll(Lists.newArrayList(filtered));
-
-        // Execute task (i.e. make the actual change, and wait for completion)
-        Task task = edgeGateway.configureServices(gatewayFeatures);
-        waitForTask(task, "remove dnat rule");
-
-        // Confirm that the rule doesn't exist,
-        // with the expected translated (i.e internal) and original (i.e. public) addresses,
-        // Retrieves a new EdgeGateway instance, to ensure we're not just looking at our local copy.
-        rules = getNatRules(getEdgeGateway());
-
-        Iterable<NatRuleType> matches = Iterables.filter(rules, Predicates.and(
-                NatPredicates.originalTargetEquals(args.publicIp, args.publicPort),
-                NatPredicates.translatedTargetEquals(args.target.getHostText(), args.target.getPort()),
-                NatPredicates.protocolMatches(args.protocol)));
-
-        if (!Iterables.isEmpty(matches)) {
-            throw new IllegalStateException(
-                    String.format("Gateway NAT Rules: the rule with translated %s and original %s:%s at %s has NOT " +
-                                    "been deleted", args.target, args.publicIp, args.publicPort, baseUrl));
+                if (!Iterables.isEmpty(matches)) {
+                    throw new IllegalStateException(
+                            String.format("Gateway NAT Rules: the rule with translated %s and original %s:%s at %s has NOT " +
+                                            "been deleted", arg.target, arg.publicIp, arg.publicPort, baseUrl));
+                }
+            }
         }
-        return HostAndPort.fromParts(args.publicIp, args.publicPort);
+    }
+    
+    public List<NatRuleType> getNatRules() throws VCloudException {
+        // Append DNAT rule to NAT service; retrieve the existing, modify it, and upload.
+        // If instead we create new objects then risk those having different config - this is *not* a delta!
 
+        synchronized (getMutex()) {
+            return getNatRules(getEdgeGateway());
+        }
     }
 
     public void enableNatService() throws VCloudException {
@@ -351,6 +339,12 @@ public class NatService {
             task.waitForTask(0);
         } catch (TimeoutException e) {
             throw Exceptions.propagate(e);
+        }
+    }
+
+    private void checkPublicIps(Iterable<String> publicIps, List<SubnetParticipationType> subnetParticipations) {
+        for (String publicIp : publicIps) {
+            checkPublicIp(publicIp, subnetParticipations);
         }
     }
     

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/PortForwardingConfig.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/PortForwardingConfig.java
@@ -1,0 +1,62 @@
+package brooklyn.networking.vclouddirector;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import brooklyn.util.net.Protocol;
+
+import com.google.common.base.Objects;
+import com.google.common.net.HostAndPort;
+
+public class PortForwardingConfig {
+    private String networkId;
+    Protocol protocol;
+    String publicIp;
+    Integer publicPort;
+    HostAndPort target;
+    
+    public PortForwardingConfig networkId(String val) {
+        this.networkId = val; return this;
+    }
+    
+    public PortForwardingConfig protocol(Protocol val) {
+        this.protocol = val; return this;
+    }
+    
+    public PortForwardingConfig publicIp(String val) {
+        this.publicIp = val; return this;
+    }
+    
+    public PortForwardingConfig publicPort(int val) {
+        this.publicPort = val; return this;
+    }
+    
+    public PortForwardingConfig target(HostAndPort val) {
+        this.target = val; return this;
+    }
+    
+    public void checkValid() {
+        checkNotNull(protocol, "protocol");
+        checkNotNull(publicIp, "publicIp");
+        checkNotNull(publicPort, publicPort);
+        checkNotNull(target, "target");
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof PortForwardingConfig)) return false;
+        PortForwardingConfig o = (PortForwardingConfig) obj;
+        return Objects.equal(networkId, o.networkId) && Objects.equal(protocol, o.protocol) 
+                && Objects.equal(publicIp, o.publicIp) && Objects.equal(publicPort, o.publicPort)
+                && Objects.equal(target, o.target);
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(networkId, protocol, publicIp, publicPort, target);
+    }
+    
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("networkId", networkId).add("protocol", protocol).add("target", target)
+                .add("publicIp", publicIp).add("publicPort", publicPort).toString();
+    }
+}

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
@@ -185,15 +185,15 @@ public class NatServiceLiveTest extends BrooklynAppLiveTestSupport {
         // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api"
         String convertedUri;
         try {
-        	URI uri = URI.create(endpoint);
+            URI uri = URI.create(endpoint);
             convertedUri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
         } catch (URISyntaxException e) {
             throw Exceptions.propagate(e);
         } 
 
         return NatService.builder()
-        		.identity(loc.getIdentity())
-        		.credential(loc.getCredential())
-        		.endpoint(convertedUri);
+                .identity(loc.getIdentity())
+                .credential(loc.getCredential())
+                .endpoint(convertedUri);
     }
 }


### PR DESCRIPTION
The support in `NatService` for multi-action (i.e. passing in a delta to be applied all at once) is laying the ground work for the approach of having a micro-service that is passes the changes and applies those with appropriate locking (potentially from multiple Brooklyn instances).