### PR TITLE
Rename package to avoid OSGi split-package problem

### DIFF
--- a/cloudstack/src/main/java/brooklyn/networking/cloudstack/portforwarding/CloudstackPortForwarder.java
+++ b/cloudstack/src/main/java/brooklyn/networking/cloudstack/portforwarding/CloudstackPortForwarder.java
@@ -25,7 +25,7 @@ import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.management.ManagementContext;
 import brooklyn.networking.cloudstack.CloudstackNew40FeaturesClient;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.networking.subnet.SubnetTier;
 import brooklyn.util.guava.Maybe;
 import brooklyn.util.net.Cidr;

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -63,4 +63,19 @@
         </dependency>
      </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>!brooklyn.networking.subnet,brooklyn.networking.*</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/common/src/main/java/brooklyn/networking/common/subnet/PortForwarder.java
+++ b/common/src/main/java/brooklyn/networking/common/subnet/PortForwarder.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package brooklyn.networking.subnet;
+package brooklyn.networking.common.subnet;
 
 import java.util.List;
 

--- a/common/src/main/java/brooklyn/networking/common/subnet/PortForwarderAsync.java
+++ b/common/src/main/java/brooklyn/networking/common/subnet/PortForwarderAsync.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package brooklyn.networking.subnet;
+package brooklyn.networking.common.subnet;
 
 import brooklyn.entity.Entity;
 import brooklyn.entity.basic.AbstractEntity;

--- a/common/src/main/java/brooklyn/networking/common/subnet/PortForwarderAsyncImpl.java
+++ b/common/src/main/java/brooklyn/networking/common/subnet/PortForwarderAsyncImpl.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package brooklyn.networking.subnet;
+package brooklyn.networking.common.subnet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/common/src/main/java/brooklyn/networking/common/subnet/PortForwarderClient.java
+++ b/common/src/main/java/brooklyn/networking/common/subnet/PortForwarderClient.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package brooklyn.networking.subnet;
+package brooklyn.networking.common.subnet;
 
 import java.util.List;
 

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarder.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarder.java
@@ -1,0 +1,7 @@
+package brooklyn.networking.subnet;
+
+/** Kept for persisted state backwards compatibility **/
+@Deprecated
+public interface PortForwarder extends brooklyn.networking.common.subnet.PortForwarder {
+
+}

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsync.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsync.java
@@ -1,0 +1,7 @@
+package brooklyn.networking.subnet;
+
+/** Kept for persisted state backwards compatibility **/
+@Deprecated
+public interface PortForwarderAsync extends brooklyn.networking.common.subnet.PortForwarderAsync {
+
+}

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsyncImpl.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsyncImpl.java
@@ -1,0 +1,15 @@
+package brooklyn.networking.subnet;
+
+import brooklyn.entity.basic.EntityLocal;
+import brooklyn.location.access.PortForwardManager;
+import brooklyn.networking.common.subnet.PortForwarder;
+
+/** Kept for persisted state backwards compatibility **/
+public class PortForwarderAsyncImpl extends brooklyn.networking.common.subnet.PortForwarderAsyncImpl {
+
+    public PortForwarderAsyncImpl(EntityLocal adjunctEntity,
+            PortForwarder portForwarder, PortForwardManager portForwardManager) {
+        super(adjunctEntity, portForwarder, portForwardManager);
+    }
+
+}

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderClient.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderClient.java
@@ -1,0 +1,13 @@
+package brooklyn.networking.subnet;
+
+import brooklyn.networking.common.subnet.PortForwarder;
+
+import com.google.common.base.Supplier;
+
+/** Kept around for persisted state backwards compatibility **/
+@Deprecated
+public class PortForwarderClient extends brooklyn.networking.common.subnet.PortForwarderClient {
+    public PortForwarderClient(Supplier<PortForwarder> supplier) {
+        super(supplier);
+    }
+}

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/DockerPortForwarder.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/DockerPortForwarder.java
@@ -38,7 +38,7 @@ import brooklyn.location.access.PortMapping;
 import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import brooklyn.management.ManagementContext;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.net.HasNetworkAddresses;
 import brooklyn.util.net.Protocol;

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/NoopPortForwarder.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/NoopPortForwarder.java
@@ -29,7 +29,7 @@ import brooklyn.location.Location;
 import brooklyn.location.PortRange;
 import brooklyn.location.access.PortForwardManager;
 import brooklyn.management.ManagementContext;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.networking.util.ConcurrentReachableAddressFinder;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.net.HasNetworkAddresses;

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/PortForwarderIptables.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/PortForwarderIptables.java
@@ -34,7 +34,7 @@ import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.basic.PortRanges;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.management.ManagementContext;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.net.HasNetworkAddresses;
 import brooklyn.util.net.Protocol;

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/subnet/JcloudsPortforwardingSubnetLocation.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/subnet/JcloudsPortforwardingSubnetLocation.java
@@ -37,7 +37,7 @@ import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.location.jclouds.JcloudsSshMachineLocation;
 import brooklyn.location.jclouds.JcloudsUtil;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.networking.util.ConcurrentReachableAddressFinder;
 import brooklyn.util.collections.MutableMap;
 import brooklyn.util.config.ConfigBag;

--- a/portforwarding/src/main/java/brooklyn/networking/portforwarding/subnet/JcloudsPortforwardingSubnetMachineLocation.java
+++ b/portforwarding/src/main/java/brooklyn/networking/portforwarding/subnet/JcloudsPortforwardingSubnetMachineLocation.java
@@ -21,7 +21,7 @@ import brooklyn.entity.basic.ConfigKeys;
 import brooklyn.location.access.BrooklynAccessUtils;
 import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.jclouds.AbstractJcloudsSubnetSshMachineLocation;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.util.net.Cidr;
 import brooklyn.util.net.Protocol;
 

--- a/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTier.java
+++ b/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTier.java
@@ -29,6 +29,8 @@ import brooklyn.location.access.BrooklynAccessUtils;
 import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.access.PortForwardManagerClient;
 import brooklyn.location.jclouds.networking.JcloudsPortForwarderExtension;
+import brooklyn.networking.common.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarderAsync;
 import brooklyn.policy.EnricherSpec;
 import brooklyn.util.flags.SetFromFlag;
 import brooklyn.util.net.Cidr;

--- a/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTierImpl.java
+++ b/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTierImpl.java
@@ -43,6 +43,10 @@ import brooklyn.location.jclouds.networking.JcloudsPortForwarderExtension;
 import brooklyn.management.internal.CollectionChangeListener;
 import brooklyn.management.internal.ManagementContextInternal;
 import brooklyn.networking.AttributeMunger;
+import brooklyn.networking.common.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarderAsync;
+import brooklyn.networking.common.subnet.PortForwarderAsyncImpl;
+import brooklyn.networking.common.subnet.PortForwarderClient;
 import brooklyn.networking.portforwarding.subnet.JcloudsPortforwardingSubnetLocation;
 import brooklyn.policy.EnricherSpec;
 import brooklyn.util.config.ConfigBag;
@@ -152,7 +156,7 @@ public class SubnetTierImpl extends AbstractEntity implements SubnetTier {
 
     protected JcloudsPortForwarderExtension newJcloudsPortForwarderExtension() {
         return new SubnetTierJcloudsPortForwarderExtension(
-                PortForwarderClient.fromMethodOnEntity(this, "getPortForwarder"), 
+                PortForwarderClient.fromMethodOnEntity(this, "getPortForwarder"),
                 getPortForwardManager());
     }
 

--- a/portforwarding/src/test/java/brooklyn/networking/portforwarding/DockerSubnetTierLiveTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/portforwarding/DockerSubnetTierLiveTest.java
@@ -29,7 +29,6 @@ import brooklyn.entity.basic.EntityAndAttribute;
 import brooklyn.entity.proxying.EntitySpec;
 import brooklyn.event.AttributeSensor;
 import brooklyn.event.basic.BasicAttributeSensor;
-import brooklyn.networking.portforwarding.DockerPortForwarder;
 import brooklyn.networking.subnet.SubnetTier;
 import brooklyn.test.Asserts;
 import brooklyn.util.net.Cidr;

--- a/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
@@ -41,6 +41,7 @@ import brooklyn.location.PortRange;
 import brooklyn.location.access.PortForwardManager;
 import brooklyn.location.basic.SshMachineLocation;
 import brooklyn.management.ManagementContext;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.networking.portforwarding.NoopPortForwarder;
 import brooklyn.test.EntityTestUtils;
 import brooklyn.test.entity.TestApplication;

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/PortForwarderVcloudDirector.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/PortForwarderVcloudDirector.java
@@ -32,7 +32,7 @@ import brooklyn.location.basic.Machines;
 import brooklyn.location.basic.PortRanges;
 import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.management.ManagementContext;
-import brooklyn.networking.subnet.PortForwarder;
+import brooklyn.networking.common.subnet.PortForwarder;
 import brooklyn.networking.subnet.SubnetTier;
 import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.net.Cidr;


### PR DESCRIPTION
Renames the common module's `brooklyn.networking.subnet` package to `brooklyn.networking.common.subnet`. Doing so prevents both the common and portforwarding modules exporting `brooklyn.networking.subnet`, which would lead to the [split packages](http://wiki.osgi.org/wiki/Split_Packages) problem.

This change will break downstream projects that use `common:brooklyn.networking.subnet`. I can spend more time on this if necessary.
