### PR TITLE
Run assembly plugin automatically during build

### DIFF
--- a/vcloud-director-nat-microservice/pom.xml
+++ b/vcloud-director-nat-microservice/pom.xml
@@ -258,6 +258,16 @@
                     </descriptors>
                     <finalName>${project.artifactId}</finalName>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Avoids the need for a separate `mvn assembly:single` step.