### PR TITLE
PortForwarderClient: backwards compatibility after names

### DIFF
--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsyncImpl.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsyncImpl.java
@@ -1,8 +1,18 @@
 package brooklyn.networking.subnet;
 
+import brooklyn.entity.Entity;
+import brooklyn.entity.basic.EntityAndAttribute;
 import brooklyn.entity.basic.EntityLocal;
+import brooklyn.location.MachineLocation;
+import brooklyn.location.PortRange;
 import brooklyn.location.access.PortForwardManager;
+import brooklyn.location.basic.Machines;
 import brooklyn.networking.common.subnet.PortForwarder;
+import brooklyn.util.net.Cidr;
+import brooklyn.util.net.Protocol;
+
+import com.google.common.base.Optional;
+import com.google.common.net.HostAndPort;
 
 /** 
  * Kept for persisted state backwards compatibility
@@ -12,9 +22,42 @@ import brooklyn.networking.common.subnet.PortForwarder;
 @Deprecated
 public class PortForwarderAsyncImpl extends brooklyn.networking.common.subnet.PortForwarderAsyncImpl {
 
+    private final PortForwarder portForwarder;
+
     public PortForwarderAsyncImpl(EntityLocal adjunctEntity,
             PortForwarder portForwarder, PortForwardManager portForwardManager) {
         super(adjunctEntity, portForwarder, portForwardManager);
+        this.portForwarder = portForwarder;
     }
 
+    private void innerClass_openFirewallPortRangeAsync(final EntityAndAttribute<String> publicIp, final PortRange portRange, final Protocol protocol, final Cidr accessingCidr) {
+        new Runnable() {
+            public void run() {
+                portForwarder.openFirewallPortRange(publicIp.getEntity(), portRange, protocol, accessingCidr);
+            }};
+    }
+
+    private void innerClass_openPortForwardingAndAdvertise(final EntityAndAttribute<Integer> privatePort, final Optional<Integer> optionalPublicPort,
+            final Protocol protocol, final Cidr accessingCidr, final EntityAndAttribute<String> whereToAdvertiseEndpoint) {
+        new Runnable() {
+            public void run() {
+                Entity entity = privatePort.getEntity();
+                Integer privatePortVal = privatePort.getValue();
+                MachineLocation machine = Machines.findUniqueMachineLocation(entity.getLocations()).get();
+                HostAndPort publicEndpoint = portForwarder.openPortForwarding(machine, privatePortVal, optionalPublicPort, protocol, accessingCidr);
+                
+                // TODO What publicIpId to use in portForwardManager.associate? Elsewhere, uses jcloudsMachine.getJcloudsId().
+                portForwarder.getPortForwardManager().associate(machine.getId(), publicEndpoint, machine, privatePortVal);
+                whereToAdvertiseEndpoint.setValue(publicEndpoint.getHostText()+":"+publicEndpoint.getPort());
+            }};
+    }
+
+    /**
+     * @deprecated since 0.7.0; use {@link brooklyn.networking.common.subnet.PortForwarderAsyncImpl.DeferredExecutor}
+     */
+    protected class DeferredExecutor<T> extends brooklyn.networking.common.subnet.PortForwarderAsyncImpl.DeferredExecutor<T> {
+        public DeferredExecutor(String description, EntityAndAttribute<T> attribute, Runnable task) {
+            super(description, attribute, task);
+        }
+    }
 }

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsyncImpl.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderAsyncImpl.java
@@ -15,7 +15,10 @@ import com.google.common.base.Optional;
 import com.google.common.net.HostAndPort;
 
 /** 
- * Kept for persisted state backwards compatibility
+ * Kept for persisted state backwards compatibility.
+ * 
+ * The inner classes are also preserved, along with the naming of anonymous inner classes (which
+ * by default will be $1, $2 etc in the order they are declared).
  * 
  * @deprecated since 0.7.0; use {@link brooklyn.networking.common.subnet.PortForwarderAsyncImpl}
  */
@@ -30,6 +33,10 @@ public class PortForwarderAsyncImpl extends brooklyn.networking.common.subnet.Po
         this.portForwarder = portForwarder;
     }
 
+    /**
+     * This method will never be called. It is purely to contain the inner class for backwards compatibility, 
+     * preserving the parameter names etc.
+     */
     private void innerClass_openFirewallPortRangeAsync(final EntityAndAttribute<String> publicIp, final PortRange portRange, final Protocol protocol, final Cidr accessingCidr) {
         new Runnable() {
             public void run() {
@@ -37,6 +44,10 @@ public class PortForwarderAsyncImpl extends brooklyn.networking.common.subnet.Po
             }};
     }
 
+    /**
+     * This method will never be called. It is purely to contain the inner class for backwards compatibility, 
+     * preserving the parameter names etc.
+     */
     private void innerClass_openPortForwardingAndAdvertise(final EntityAndAttribute<Integer> privatePort, final Optional<Integer> optionalPublicPort,
             final Protocol protocol, final Cidr accessingCidr, final EntityAndAttribute<String> whereToAdvertiseEndpoint) {
         new Runnable() {
@@ -53,6 +64,8 @@ public class PortForwarderAsyncImpl extends brooklyn.networking.common.subnet.Po
     }
 
     /**
+     * Kept for persisted state backwards compatibility.
+     * 
      * @deprecated since 0.7.0; use {@link brooklyn.networking.common.subnet.PortForwarderAsyncImpl.DeferredExecutor}
      */
     protected class DeferredExecutor<T> extends brooklyn.networking.common.subnet.PortForwarderAsyncImpl.DeferredExecutor<T> {

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderClient.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderClient.java
@@ -1,6 +1,10 @@
 package brooklyn.networking.subnet;
 
+import brooklyn.config.ConfigKey;
+import brooklyn.entity.Entity;
+import brooklyn.event.AttributeSensor;
 import brooklyn.networking.common.subnet.PortForwarder;
+import brooklyn.util.exceptions.Exceptions;
 
 import com.google.common.base.Supplier;
 
@@ -13,5 +17,47 @@ import com.google.common.base.Supplier;
 public class PortForwarderClient extends brooklyn.networking.common.subnet.PortForwarderClient {
     public PortForwarderClient(Supplier<PortForwarder> supplier) {
         super(supplier);
+    }
+    
+    private static PortForwarder innerClass_fromMethodOnEntity(final Entity entity, final String getterMethodOnEntity) {
+        return new PortForwarderClient(new Supplier<PortForwarder>() {
+            @Override
+            public PortForwarder get() {
+                PortForwarder result;
+                try {
+                    result = (PortForwarder) entity.getClass().getMethod(getterMethodOnEntity).invoke(entity);
+                } catch (Exception e) {
+                    Exceptions.propagateIfFatal(e);
+                    throw new IllegalStateException("Cannot invoke "+getterMethodOnEntity+" on "+entity+" ("+entity.getClass()+"): "+e, e);
+                }
+                if (result==null)
+                    throw new IllegalStateException("No PortForwarder available via "+getterMethodOnEntity+" on "+entity+" (returned null)");
+                return result;
+            }
+        });
+    }
+    
+    private static PortForwarder innerClass_fromConfigOnEntity(final Entity entity, final ConfigKey<PortForwarder> configOnEntity) {
+        return new PortForwarderClient(new Supplier<PortForwarder>() {
+            @Override
+            public PortForwarder get() {
+                PortForwarder result = (PortForwarder) entity.getConfig(configOnEntity);
+                if (result==null)
+                    throw new IllegalStateException("No PortForwarder available via "+configOnEntity+" on "+entity+" (returned null)");
+                return result;
+            }
+        });
+    }
+    
+    private static PortForwarder innerClass_fromAttributeOnEntity(final Entity entity, final AttributeSensor<PortForwarder> attributeOnEntity) {
+        return new PortForwarderClient(new Supplier<PortForwarder>() {
+            @Override
+            public PortForwarder get() {
+                PortForwarder result = (PortForwarder) entity.getAttribute(attributeOnEntity);
+                if (result==null)
+                    throw new IllegalStateException("No PortForwarder available via "+attributeOnEntity+" on "+entity+" (returned null)");
+                return result;
+            }
+        });
     }
 }

--- a/common/src/main/java/brooklyn/networking/subnet/PortForwarderClient.java
+++ b/common/src/main/java/brooklyn/networking/subnet/PortForwarderClient.java
@@ -9,7 +9,10 @@ import brooklyn.util.exceptions.Exceptions;
 import com.google.common.base.Supplier;
 
 /** 
- * Kept for persisted state backwards compatibility
+ * Kept for persisted state backwards compatibility.
+ * 
+ * The inner classes are also preserved, along with the naming of anonymous inner classes (which
+ * by default will be $1, $2 etc in the order they are declared).
  * 
  * @deprecated since 0.7.0; use {@link brooklyn.networking.common.subnet.PortForwarderClient}
  */
@@ -19,6 +22,10 @@ public class PortForwarderClient extends brooklyn.networking.common.subnet.PortF
         super(supplier);
     }
     
+    /**
+     * This method will never be called. It is purely to contain the inner class for backwards compatibility, 
+     * preserving the parameter names etc.
+     */
     private static PortForwarder innerClass_fromMethodOnEntity(final Entity entity, final String getterMethodOnEntity) {
         return new PortForwarderClient(new Supplier<PortForwarder>() {
             @Override
@@ -37,6 +44,10 @@ public class PortForwarderClient extends brooklyn.networking.common.subnet.PortF
         });
     }
     
+    /**
+     * This method will never be called. It is purely to contain the inner class for backwards compatibility, 
+     * preserving the parameter names etc.
+     */
     private static PortForwarder innerClass_fromConfigOnEntity(final Entity entity, final ConfigKey<PortForwarder> configOnEntity) {
         return new PortForwarderClient(new Supplier<PortForwarder>() {
             @Override
@@ -49,6 +60,10 @@ public class PortForwarderClient extends brooklyn.networking.common.subnet.PortF
         });
     }
     
+    /**
+     * This method will never be called. It is purely to contain the inner class for backwards compatibility, 
+     * preserving the parameter names etc.
+     */
     private static PortForwarder innerClass_fromAttributeOnEntity(final Entity entity, final AttributeSensor<PortForwarder> attributeOnEntity) {
         return new PortForwarderClient(new Supplier<PortForwarder>() {
             @Override


### PR DESCRIPTION
- The PortForwarderClient package was previously renamed, leaving the old named PortForwarderClient there for backwards compatibility reasons.
- This adds the nested inner classes, which are required for being able to deserialise previously persisted state.
- Does same for PortForwarderAsyncImpl's inner classes