### PR TITLE
Nat micro service: handle duplicate targets

### DIFF
--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
@@ -53,6 +53,9 @@ import com.vmware.vcloud.api.rest.schema.NatRuleType;
  */
 public abstract class AbstractNatServiceLiveTest extends BrooklynAppLiveTestSupport {
 
+    // TODO Want test for concurrent interleaved open and close calls (similar idea to 
+    // testAddNatRulesConcurrently).
+    
     private static final Logger LOG = LoggerFactory.getLogger(AbstractNatServiceLiveTest.class);
 
     public static final String LOCATION_SPEC = "canopy-vCHS";


### PR DESCRIPTION
- Handle concurrent (batched) calls with duplicates in
  NatServiceDispatcher.
- Previously was failing because result was different size from input