### PR TITLE
Fix for TAI2.0 environment

### DIFF
--- a/docs/vCD-nat-microservice.md
+++ b/docs/vCD-nat-microservice.md
@@ -1,20 +1,23 @@
 DNAT Micro-service
 ===
 
-The DNAT micro-service provides a single service for multiple AMP servers to make
+The DNAT micro-service provides a single service for multiple Brooklyn servers to make
 concurrent changes to the DNAT rules on a vcloud-director gateway. This will 
 prevent a race condition that can occur as the vCD REST API requires that the full
 list of DNAT rules be download, modified, then the complete list uploaded in order
 to make changes to the rules.
 
 The instructions below assume that the micro-service is running on the same server 
-as AMP, which may not be the case in production. If the micro-service and AMP
+as Brooklyn, which may not be the case in production. If the micro-service and Brooklyn
 are running on different servers, the endpoint configured in brooklyn.properties
 should be changed to reflect the address of the micro-service instead of 'localhost'
 
 NOTE: There should be one and only one DNAT micro-service per vOrg. If multiple
-rAMP servers are targeting the same vOrg (such as in development / test) then all
-rAMP servers should be using the same micro-service.
+Brooklyn servers are targeting the same vOrg (such as in development / test) then all
+Brooklyn servers should be using the same micro-service.
+
+
+### Deployment and Configuration
 
 To deploy the micro-service:
 
@@ -55,6 +58,9 @@ my-vorg-2.trustStorePassword=
 my-vorg-2.portRange=12000+
 ```
 
+
+### Launching
+
 * To start the microservice, use the `start.sh` script.
 
   * Optionally `--publicPortRange <range>` can be passed as a command line argument,
@@ -67,10 +73,27 @@ my-vorg-2.portRange=12000+
 nohup ./start.sh launch --endpointsProperties ~/.brooklyn/dnat-microservice.properties &
 ```
 
-* To enable AMP to use the service, add the following to your `brooklyn.properties`
-  file (with your URL, obviously) and restart rAMP:
+
+### Configuring Brooklyn
+
+* To enable Brooklyn to use the service, add the following to your `brooklyn.properties`
+  file (with your URL, obviously) and restart Brooklyn:
 
 ```
 # Enable NAT micro-service
 advancednetworking.vcloud.network.microservice.endpoint=https://localhost:8443
 ```
+
+
+### Using the REST API
+
+The REST api calls often include the following parameters:
+
+* `endpoint`: the vCloud Director URL, without the suffix `/api`.
+  e.g. https://emea01.canopy-cloud.com or https://emea01.canopy-cloud.com/cloud/org/cct-emea01/,
+  where the latter includes the vOrg.
+
+* `identity`: either the `<user>@<vOrg>`, or just the `<user>` (the latter only if vOrg is 
+  included in the endpoint) 
+
+* `credential`: the password

--- a/vcloud-director-nat-microservice/pom.xml
+++ b/vcloud-director-nat-microservice/pom.xml
@@ -241,7 +241,7 @@
         <dependency>
             <groupId>io.cloudsoft.jclouds.labs</groupId>
             <artifactId>vcloud-director</artifactId>
-            <version>1.9.0-SNAPSHOT</version>
+            <version>1.9.0-rc2</version>
             <scope>test</scope>
         </dependency>
 

--- a/vcloud-director-nat-microservice/pom.xml
+++ b/vcloud-director-nat-microservice/pom.xml
@@ -241,7 +241,7 @@
         <dependency>
             <groupId>io.cloudsoft.jclouds.labs</groupId>
             <artifactId>vcloud-director</artifactId>
-            <version>1.8.2-alpha-cloudsoft.8</version>
+            <version>1.9.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 

--- a/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/api/NatServiceApi.java
+++ b/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/api/NatServiceApi.java
@@ -20,6 +20,18 @@ import com.wordnik.swagger.core.ApiErrors;
 import com.wordnik.swagger.core.ApiOperation;
 import com.wordnik.swagger.core.ApiParam;
 
+/**
+ * REST api for accessing/updating NAT rules on vCloud Director's Edge Gateway.
+ * 
+ * The Edge Gateway does not handle concurrent access (because an update requires
+ * a chain of calls to: 1) read existing; 2) create list of existing+new; 3) write everything.
+ * 
+ * Therefore this service provides controlled access to ensure updates from multiple callers
+ * are done safely and sequentially.
+ * 
+ * The {@code identity} can be the {@code <user>@<vOrg>}, or alternatively just the {@code <user>}
+ * if the vOrg is included in the endpoint URL.
+ */
 @Path("/v1/nat")
 @Apidoc("Nat")
 @Produces(MediaType.APPLICATION_JSON)

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
@@ -38,9 +38,9 @@ import com.google.common.net.UrlEscapers;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.GenericType;
 
-public class NatServiceMicroserviceLiveTest extends AbstractRestApiTest {
+public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRestApiTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NatServiceMicroserviceLiveTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(NatServiceMicroserviceAbstractLiveTest.class);
 
     private static final int STARTING_PORT = 19980;
     private static final PortRange DEFAULT_PORT_RANGE = PortRanges.fromString("19980-19999");
@@ -57,11 +57,13 @@ public class NatServiceMicroserviceLiveTest extends AbstractRestApiTest {
 
     private Escaper escaper = UrlEscapers.urlPathSegmentEscaper();
     
+    protected abstract String getLocationSpec();
+
     @BeforeClass(alwaysRun=true)
     @Override
     public void setUp() throws Exception {
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
-        loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("canopy-vCHS");
+        loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(getLocationSpec());
         endpoint = endpoint(loc);
         identity = loc.getIdentity();
         credential = loc.getCredential();
@@ -86,7 +88,7 @@ public class NatServiceMicroserviceLiveTest extends AbstractRestApiTest {
     
     @Test(groups="Live")
     public void testGetNatRules() throws Exception {
-        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("canopy-vCHS");
+        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(getLocationSpec());
         String url = "/v1/nat"
                 + "?endpoint="+escaper.escape(endpoint)
                 + "&identity="+escaper.escape(identity)

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
@@ -17,6 +17,12 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.escape.Escaper;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.UrlEscapers;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.GenericType;
+
 import brooklyn.config.BrooklynProperties;
 import brooklyn.entity.basic.Entities;
 import brooklyn.location.PortRange;
@@ -32,11 +38,6 @@ import brooklyn.util.exceptions.Exceptions;
 import brooklyn.util.guava.Maybe;
 import brooklyn.util.net.Protocol;
 
-import com.google.common.escape.Escaper;
-import com.google.common.net.HostAndPort;
-import com.google.common.net.UrlEscapers;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
 
 public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRestApiTest {
 

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceTAI2LiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceTAI2LiveTest.java
@@ -1,0 +1,220 @@
+package brooklyn.networking.vclouddirector.natmicroservice;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Random;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.escape.Escaper;
+import com.google.common.net.HostAndPort;
+import com.google.common.net.UrlEscapers;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.api.client.GenericType;
+
+import brooklyn.config.BrooklynProperties;
+import brooklyn.entity.basic.Entities;
+import brooklyn.location.PortRange;
+import brooklyn.location.basic.PortRanges;
+import brooklyn.location.jclouds.JcloudsLocation;
+import brooklyn.management.internal.LocalManagementContext;
+import brooklyn.networking.vclouddirector.NatServiceDispatcher;
+import brooklyn.networking.vclouddirector.NatServiceDispatcher.EndpointConfig;
+import brooklyn.networking.vclouddirector.PortForwardingConfig;
+import brooklyn.networking.vclouddirector.natservice.domain.NatRuleSummary;
+import brooklyn.test.entity.LocalManagementContextForTests;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.guava.Maybe;
+import brooklyn.util.net.Protocol;
+
+public class NatServiceMicroserviceTAI2LiveTest extends AbstractRestApiTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NatServiceMicroserviceTAI2LiveTest.class);
+
+    private static final int STARTING_PORT = 19980;
+    private static final PortRange DEFAULT_PORT_RANGE = PortRanges.fromString("19980-19999");
+    
+    private static final String INTERNAL_MACHINE_IP = "192.168.109.10";
+
+    private LocalManagementContext mgmt;
+    private JcloudsLocation loc;
+    private String endpoint;
+    private String identity;
+    private String credential;
+    private String publicIp;
+    private Random random = new Random(getClass().getName().hashCode());
+
+    private Escaper escaper = UrlEscapers.urlPathSegmentEscaper();
+    
+    @BeforeClass(alwaysRun=true)
+    @Override
+    public void setUp() throws Exception {
+        mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+        loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("Canopy_TAI_2");
+        endpoint = endpoint(loc);
+        identity = loc.getIdentity();
+        credential = loc.getCredential();
+        publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+
+        super.setUp();
+    }
+
+    @AfterClass(alwaysRun=true)
+    @Override
+    public void tearDown() throws Exception {
+        if (mgmt != null) Entities.destroyAll(mgmt);
+        super.tearDown();
+    }
+
+    protected NatServiceDispatcher newNatServiceDispatcher() {
+        return NatServiceDispatcher.builder()
+                .endpoint(endpoint, new EndpointConfig(null, null, null))
+                .portRange(DEFAULT_PORT_RANGE)
+                .build();
+    }
+    
+    @Test(groups="Live")
+    public void testGetNatRules() throws Exception {
+        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("Canopy_TAI_2");
+        String url = "/v1/nat"
+                + "?endpoint="+escaper.escape(endpoint)
+                + "&identity="+escaper.escape(identity)
+                + "&credential="+escaper.escape(credential);
+        List<NatRuleSummary> data = client().resource(url).get(new GenericType<List<NatRuleSummary>>() {});
+        LOG.info("/v1/nat gives: "+data);
+        
+        // Expect at least one rule
+        assertFalse(data.isEmpty());
+    }
+
+    @Test(groups="Live")
+    public void testOpenAndDeleteNatRule() throws Exception {
+        runOpenAndDeleteNatRule(null, null);
+    }
+
+    @Test(groups="Live")
+    public void testOpenAndDeleteNatRuleWithExplicitPublicPort() throws Exception {
+        runOpenAndDeleteNatRule(STARTING_PORT+10, null);
+    }
+    
+    @Test(groups="Live")
+    public void testOpenAndDeleteNatRuleWithExplicitPublicPortRange() throws Throwable {
+        runOpenAndDeleteNatRule(null, PortRanges.fromString((STARTING_PORT+5)+"-"+(STARTING_PORT+10)));
+    }
+    
+    protected void runOpenAndDeleteNatRule(Integer publicPort, PortRange publicPortRange) throws Exception {
+        HostAndPort publicEndpoint = (publicPort == null)
+                ? HostAndPort.fromString(publicIp) 
+                : HostAndPort.fromParts(publicIp, publicPort);
+        HostAndPort targetEndpoint = HostAndPort.fromParts(INTERNAL_MACHINE_IP, 1+random.nextInt(1000));
+        String protocol = "tcp";
+
+        // Open the NAT rule
+        String openUrl = "/v1/nat"
+                + "?endpoint="+escaper.escape(endpoint)
+                + "&identity="+escaper.escape(identity)
+                + "&credential="+escaper.escape(credential)
+                + "&protocol=" + protocol
+                + "&original=" + publicEndpoint.toString()
+                + (publicPortRange == null ? "" : "&originalPortRange="+publicPortRange.toString())
+                + "&translated=" + targetEndpoint.toString();
+        ClientResponse openResponse = client().resource(openUrl).put(ClientResponse.class);
+        HostAndPort result = HostAndPort.fromString(openResponse.getEntity(String.class));
+        try {
+            assertEquals(openResponse.getStatus(), 200);
+            if (publicPort != null) {
+                assertEquals(result, publicEndpoint);
+            } else {
+                assertEquals(result.getHostText(), publicIp, "result="+result);
+                assertTrue(result.hasPort(), "result="+result);
+                if (publicPortRange != null) {
+                    assertTrue(contains(publicPortRange, result.getPort()), "result="+result+"; range="+publicPortRange);
+                } else {
+                    assertTrue(contains(DEFAULT_PORT_RANGE, result.getPort()), "result="+result+"; range="+DEFAULT_PORT_RANGE);
+                }
+            }
+            
+            LOG.info("NAT Rule created: "+result);
+            assertRuleExists(result, targetEndpoint, protocol);
+            
+            // Delete the rule
+            String deleteUrl = "/v1/nat"
+                    + "?endpoint="+escaper.escape(endpoint)
+                    + "&identity="+escaper.escape(identity)
+                    + "&credential="+escaper.escape(credential)
+                    + "&protocol=" + protocol
+                    + "&original=" + result.toString()
+                    + "&translated=" + targetEndpoint.toString();
+            ClientResponse deleteResponse = client().resource(deleteUrl).delete(ClientResponse.class);
+            assertEquals(deleteResponse.getStatus(), 200);
+            
+            // Confirm rule no longer there
+            LOG.info("NAT Rule deleted: "+result);
+            assertRuleNotExists(result, targetEndpoint, protocol);
+        } finally {
+            if (result != null) {
+                dispatcher.closePortForwarding(endpoint, identity, credential, new PortForwardingConfig()
+                        .protocol(Protocol.TCP)
+                        .publicEndpoint(result)
+                        .targetEndpoint(targetEndpoint));
+            }
+        }
+    }
+    
+    protected void assertRuleExists(HostAndPort publicEndpoint, HostAndPort targetEndpoint, String protocol) throws Exception {
+        Maybe<NatRuleSummary> rule = tryFindRule(publicEndpoint, targetEndpoint, protocol);
+        assertNotNull(rule.get(), "rule="+rule);
+    }
+
+    protected void assertRuleNotExists(HostAndPort publicEndpoint, HostAndPort targetEndpoint, String protocol) throws Exception {
+        Maybe<NatRuleSummary> rule = tryFindRule(publicEndpoint, targetEndpoint, protocol);
+        assertTrue(rule.isAbsent(), "rule="+rule);
+    }
+
+    protected Maybe<NatRuleSummary> tryFindRule(HostAndPort publicEndpoint, HostAndPort targetEndpoint, String protocol) throws Exception {
+        // Confirm the NAT rule exists
+        String getUrl = "/v1/nat"
+                + "?endpoint="+escaper.escape(endpoint)
+                + "&identity="+escaper.escape(identity)
+                + "&credential="+escaper.escape(credential);
+        List<NatRuleSummary> rules = client().resource(getUrl).get(new GenericType<List<NatRuleSummary>>() {});
+        for (NatRuleSummary rule : rules) {
+            if (publicEndpoint.getHostText().equals(rule.getOriginalIp()) 
+                    && Integer.toString(publicEndpoint.getPort()).equals(rule.getOriginalPort())
+                    && targetEndpoint.getHostText().equals(rule.getTranslatedIp()) 
+                    && Integer.toString(targetEndpoint.getPort()).equals(rule.getTranslatedPort())
+                    && protocol.equalsIgnoreCase(rule.getProtocol())) {
+                return Maybe.of(rule);
+            }
+        }
+        return Maybe.absent("No rule for "+publicEndpoint+"->"+targetEndpoint);
+    }
+
+    protected boolean contains(PortRange range, int port) {
+        for (int contender : range) {
+            if (contender == port) return true;
+        }
+        return false;
+    }
+    
+    protected String endpoint(JcloudsLocation loc) {
+        // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api"
+        try {
+            URI uri = URI.create(loc.getEndpoint());
+            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
+        } catch (URISyntaxException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+}

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceTAI2LiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceTAI2LiveTest.java
@@ -1,220 +1,25 @@
 package brooklyn.networking.vclouddirector.natmicroservice;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Random;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.escape.Escaper;
-import com.google.common.net.HostAndPort;
-import com.google.common.net.UrlEscapers;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.GenericType;
+/**
+ * Tests against TAI 2.0 (i.e. a vcloud-director environment kinds made available by Canopy Cloud).
+ */
+@Test
+public class NatServiceMicroserviceTAI2LiveTest extends NatServiceMicroserviceAbstractLiveTest {
 
-import brooklyn.config.BrooklynProperties;
-import brooklyn.entity.basic.Entities;
-import brooklyn.location.PortRange;
-import brooklyn.location.basic.PortRanges;
-import brooklyn.location.jclouds.JcloudsLocation;
-import brooklyn.management.internal.LocalManagementContext;
-import brooklyn.networking.vclouddirector.NatServiceDispatcher;
-import brooklyn.networking.vclouddirector.NatServiceDispatcher.EndpointConfig;
-import brooklyn.networking.vclouddirector.PortForwardingConfig;
-import brooklyn.networking.vclouddirector.natservice.domain.NatRuleSummary;
-import brooklyn.test.entity.LocalManagementContextForTests;
-import brooklyn.util.exceptions.Exceptions;
-import brooklyn.util.guava.Maybe;
-import brooklyn.util.net.Protocol;
-
-public class NatServiceMicroserviceTAI2LiveTest extends AbstractRestApiTest {
-
+    @SuppressWarnings("unused")
     private static final Logger LOG = LoggerFactory.getLogger(NatServiceMicroserviceTAI2LiveTest.class);
 
-    private static final int STARTING_PORT = 19980;
-    private static final PortRange DEFAULT_PORT_RANGE = PortRanges.fromString("19980-19999");
-    
-    private static final String INTERNAL_MACHINE_IP = "192.168.109.10";
-
-    private LocalManagementContext mgmt;
-    private JcloudsLocation loc;
-    private String endpoint;
-    private String identity;
-    private String credential;
-    private String publicIp;
-    private Random random = new Random(getClass().getName().hashCode());
-
-    private Escaper escaper = UrlEscapers.urlPathSegmentEscaper();
-    
-    @BeforeClass(alwaysRun=true)
     @Override
-    public void setUp() throws Exception {
-        mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
-        loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("Canopy_TAI_2");
-        endpoint = endpoint(loc);
-        identity = loc.getIdentity();
-        credential = loc.getCredential();
-        publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
-
-        super.setUp();
-    }
-
-    @AfterClass(alwaysRun=true)
-    @Override
-    public void tearDown() throws Exception {
-        if (mgmt != null) Entities.destroyAll(mgmt);
-        super.tearDown();
-    }
-
-    protected NatServiceDispatcher newNatServiceDispatcher() {
-        return NatServiceDispatcher.builder()
-                .endpoint(endpoint, new EndpointConfig(null, null, null))
-                .portRange(DEFAULT_PORT_RANGE)
-                .build();
+    protected String getLocationSpec() {
+        return "Canopy_TAI_2";
     }
     
-    @Test(groups="Live")
-    public void testGetNatRules() throws Exception {
-        JcloudsLocation loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve("Canopy_TAI_2");
-        String url = "/v1/nat"
-                + "?endpoint="+escaper.escape(endpoint)
-                + "&identity="+escaper.escape(identity)
-                + "&credential="+escaper.escape(credential);
-        List<NatRuleSummary> data = client().resource(url).get(new GenericType<List<NatRuleSummary>>() {});
-        LOG.info("/v1/nat gives: "+data);
-        
-        // Expect at least one rule
-        assertFalse(data.isEmpty());
-    }
-
     @Test(groups="Live")
     public void testOpenAndDeleteNatRule() throws Exception {
-        runOpenAndDeleteNatRule(null, null);
-    }
-
-    @Test(groups="Live")
-    public void testOpenAndDeleteNatRuleWithExplicitPublicPort() throws Exception {
-        runOpenAndDeleteNatRule(STARTING_PORT+10, null);
-    }
-    
-    @Test(groups="Live")
-    public void testOpenAndDeleteNatRuleWithExplicitPublicPortRange() throws Throwable {
-        runOpenAndDeleteNatRule(null, PortRanges.fromString((STARTING_PORT+5)+"-"+(STARTING_PORT+10)));
-    }
-    
-    protected void runOpenAndDeleteNatRule(Integer publicPort, PortRange publicPortRange) throws Exception {
-        HostAndPort publicEndpoint = (publicPort == null)
-                ? HostAndPort.fromString(publicIp) 
-                : HostAndPort.fromParts(publicIp, publicPort);
-        HostAndPort targetEndpoint = HostAndPort.fromParts(INTERNAL_MACHINE_IP, 1+random.nextInt(1000));
-        String protocol = "tcp";
-
-        // Open the NAT rule
-        String openUrl = "/v1/nat"
-                + "?endpoint="+escaper.escape(endpoint)
-                + "&identity="+escaper.escape(identity)
-                + "&credential="+escaper.escape(credential)
-                + "&protocol=" + protocol
-                + "&original=" + publicEndpoint.toString()
-                + (publicPortRange == null ? "" : "&originalPortRange="+publicPortRange.toString())
-                + "&translated=" + targetEndpoint.toString();
-        ClientResponse openResponse = client().resource(openUrl).put(ClientResponse.class);
-        HostAndPort result = HostAndPort.fromString(openResponse.getEntity(String.class));
-        try {
-            assertEquals(openResponse.getStatus(), 200);
-            if (publicPort != null) {
-                assertEquals(result, publicEndpoint);
-            } else {
-                assertEquals(result.getHostText(), publicIp, "result="+result);
-                assertTrue(result.hasPort(), "result="+result);
-                if (publicPortRange != null) {
-                    assertTrue(contains(publicPortRange, result.getPort()), "result="+result+"; range="+publicPortRange);
-                } else {
-                    assertTrue(contains(DEFAULT_PORT_RANGE, result.getPort()), "result="+result+"; range="+DEFAULT_PORT_RANGE);
-                }
-            }
-            
-            LOG.info("NAT Rule created: "+result);
-            assertRuleExists(result, targetEndpoint, protocol);
-            
-            // Delete the rule
-            String deleteUrl = "/v1/nat"
-                    + "?endpoint="+escaper.escape(endpoint)
-                    + "&identity="+escaper.escape(identity)
-                    + "&credential="+escaper.escape(credential)
-                    + "&protocol=" + protocol
-                    + "&original=" + result.toString()
-                    + "&translated=" + targetEndpoint.toString();
-            ClientResponse deleteResponse = client().resource(deleteUrl).delete(ClientResponse.class);
-            assertEquals(deleteResponse.getStatus(), 200);
-            
-            // Confirm rule no longer there
-            LOG.info("NAT Rule deleted: "+result);
-            assertRuleNotExists(result, targetEndpoint, protocol);
-        } finally {
-            if (result != null) {
-                dispatcher.closePortForwarding(endpoint, identity, credential, new PortForwardingConfig()
-                        .protocol(Protocol.TCP)
-                        .publicEndpoint(result)
-                        .targetEndpoint(targetEndpoint));
-            }
-        }
-    }
-    
-    protected void assertRuleExists(HostAndPort publicEndpoint, HostAndPort targetEndpoint, String protocol) throws Exception {
-        Maybe<NatRuleSummary> rule = tryFindRule(publicEndpoint, targetEndpoint, protocol);
-        assertNotNull(rule.get(), "rule="+rule);
-    }
-
-    protected void assertRuleNotExists(HostAndPort publicEndpoint, HostAndPort targetEndpoint, String protocol) throws Exception {
-        Maybe<NatRuleSummary> rule = tryFindRule(publicEndpoint, targetEndpoint, protocol);
-        assertTrue(rule.isAbsent(), "rule="+rule);
-    }
-
-    protected Maybe<NatRuleSummary> tryFindRule(HostAndPort publicEndpoint, HostAndPort targetEndpoint, String protocol) throws Exception {
-        // Confirm the NAT rule exists
-        String getUrl = "/v1/nat"
-                + "?endpoint="+escaper.escape(endpoint)
-                + "&identity="+escaper.escape(identity)
-                + "&credential="+escaper.escape(credential);
-        List<NatRuleSummary> rules = client().resource(getUrl).get(new GenericType<List<NatRuleSummary>>() {});
-        for (NatRuleSummary rule : rules) {
-            if (publicEndpoint.getHostText().equals(rule.getOriginalIp()) 
-                    && Integer.toString(publicEndpoint.getPort()).equals(rule.getOriginalPort())
-                    && targetEndpoint.getHostText().equals(rule.getTranslatedIp()) 
-                    && Integer.toString(targetEndpoint.getPort()).equals(rule.getTranslatedPort())
-                    && protocol.equalsIgnoreCase(rule.getProtocol())) {
-                return Maybe.of(rule);
-            }
-        }
-        return Maybe.absent("No rule for "+publicEndpoint+"->"+targetEndpoint);
-    }
-
-    protected boolean contains(PortRange range, int port) {
-        for (int contender : range) {
-            if (contender == port) return true;
-        }
-        return false;
-    }
-    
-    protected String endpoint(JcloudsLocation loc) {
-        // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api"
-        try {
-            URI uri = URI.create(loc.getEndpoint());
-            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
-        } catch (URISyntaxException e) {
-            throw Exceptions.propagate(e);
-        }
+        super.testOpenAndDeleteNatRule();
     }
 }

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceTai1LiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceTai1LiveTest.java
@@ -1,0 +1,20 @@
+package brooklyn.networking.vclouddirector.natmicroservice;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests against TAI 1.2 (i.e. a vcloud-director environment kinds made available by Canopy Cloud).
+ */
+@Test
+public class NatServiceMicroserviceTai1LiveTest extends NatServiceMicroserviceAbstractLiveTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger LOG = LoggerFactory.getLogger(NatServiceMicroserviceTai1LiveTest.class);
+
+    @Override
+    protected String getLocationSpec() {
+        return "Canopy_TAI_TEST";
+    }
+}

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceVcloudAirLiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceVcloudAirLiveTest.java
@@ -1,0 +1,20 @@
+package brooklyn.networking.vclouddirector.natmicroservice;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests against vCloud Air (previously known as vCHS).
+ */
+@Test
+public class NatServiceMicroserviceVcloudAirLiveTest extends NatServiceMicroserviceAbstractLiveTest {
+
+    @SuppressWarnings("unused")
+    private static final Logger LOG = LoggerFactory.getLogger(NatServiceMicroserviceVcloudAirLiveTest.class);
+
+    @Override
+    protected String getLocationSpec() {
+        return "canopy-vCHS";
+    }
+}

--- a/vcloud-director-portforwarding/pom.xml
+++ b/vcloud-director-portforwarding/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>io.cloudsoft.jclouds.labs</groupId>
             <artifactId>vcloud-director</artifactId>
-            <version>1.9.0-SNAPSHOT</version>
+            <version>1.9.0-rc2</version>
         </dependency>
 
         <dependency>

--- a/vcloud-director-portforwarding/pom.xml
+++ b/vcloud-director-portforwarding/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>io.cloudsoft.jclouds.labs</groupId>
             <artifactId>vcloud-director</artifactId>
-            <version>1.8.2-alpha-cloudsoft.8</version>
+            <version>1.9.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatDirectClient.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatDirectClient.java
@@ -4,12 +4,12 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
 
-import brooklyn.location.jclouds.JcloudsLocation;
-import brooklyn.util.exceptions.Exceptions;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
+
+import brooklyn.location.jclouds.JcloudsLocation;
+import brooklyn.util.exceptions.Exceptions;
 
 public class NatDirectClient implements NatClient {
 
@@ -71,11 +71,21 @@ public class NatDirectClient implements NatClient {
     
     // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api"
     public static String transformEndpoint(String endpoint) {
+        return transformEndpoint(endpoint, null);
+    }
+
+    // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api" + tenant
+    // i.e.: https://emea01.canopy-cloud.com/cloud/org/cct-emea01/
+    public static String transformEndpoint(String endpoint, String tenant) {
+        String path = null;
+        if (tenant != null) {
+            path = String.format("/cloud/org/%s", tenant);
+        }
         try {
             URI uri = URI.create(endpoint);
-            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
+            return new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), path, null, null).toString();
         } catch (URISyntaxException e) {
             throw Exceptions.propagate(e);
-        } 
+        }
     }
 }

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatDirectClient.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatDirectClient.java
@@ -76,10 +76,10 @@ public class NatDirectClient implements NatClient {
 
     // jclouds endpoint has suffix "/api"; but VMware SDK wants it without "api" + tenant
     // i.e.: https://emea01.canopy-cloud.com/cloud/org/cct-emea01/
-    public static String transformEndpoint(String endpoint, String tenant) {
+    public static String transformEndpoint(String endpoint, String vOrg) {
         String path = null;
-        if (tenant != null) {
-            path = String.format("/cloud/org/%s", tenant);
+        if (vOrg != null) {
+            path = String.format("/cloud/org/%s", vOrg);
         }
         try {
             URI uri = URI.create(endpoint);

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatMicroserviceClient.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatMicroserviceClient.java
@@ -14,7 +14,9 @@ import brooklyn.util.http.HttpToolResponse;
 import brooklyn.util.net.Urls;
 
 import com.google.common.annotations.Beta;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.escape.Escaper;
 import com.google.common.net.HostAndPort;
 import com.google.common.net.UrlEscapers;
@@ -44,9 +46,10 @@ public class NatMicroserviceClient implements NatClient {
     private final String identity;
 
     public NatMicroserviceClient(String microserviceUri, JcloudsLocation loc) {
+        String tenantAndIdentity = checkNotNull(loc.getIdentity(), "identity");
         this.microserviceUri = checkNotNull(microserviceUri, "microserviceUri");
-        endpoint = NatDirectClient.transformEndpoint(loc.getEndpoint());
-        this.identity = checkNotNull(loc.getIdentity(), "identity");
+        endpoint = NatDirectClient.transformEndpoint(loc.getEndpoint(), Iterables.get(Splitter.on("@").split(tenantAndIdentity), 1));
+        this.identity = Iterables.get(Splitter.on("@").split(tenantAndIdentity), 0);
         this.credential = checkNotNull(loc.getCredential(), "credential");
     }
 

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatMicroserviceClient.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatMicroserviceClient.java
@@ -1,5 +1,6 @@
 package brooklyn.networking.vclouddirector;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.net.URI;
@@ -46,10 +47,13 @@ public class NatMicroserviceClient implements NatClient {
     private final String identity;
 
     public NatMicroserviceClient(String microserviceUri, JcloudsLocation loc) {
-        String tenantAndIdentity = checkNotNull(loc.getIdentity(), "identity");
+        String identityAtVOrg = checkNotNull(loc.getIdentity(), "identity");
+        checkArgument(identityAtVOrg.contains("@"));
+        String vOrg = identityAtVOrg.substring(identityAtVOrg.lastIndexOf("@") + 1);
+        String identity = identityAtVOrg.substring(0, identityAtVOrg.lastIndexOf("@"));
         this.microserviceUri = checkNotNull(microserviceUri, "microserviceUri");
-        endpoint = NatDirectClient.transformEndpoint(loc.getEndpoint(), Iterables.get(Splitter.on("@").split(tenantAndIdentity), 1));
-        this.identity = Iterables.get(Splitter.on("@").split(tenantAndIdentity), 0);
+        endpoint = NatDirectClient.transformEndpoint(loc.getEndpoint(), vOrg);
+        this.identity = identity;
         this.credential = checkNotNull(loc.getCredential(), "credential");
     }
 

--- a/vcloud-director-portforwarding/src/test/java/brooklyn/networking/vclouddirector/VcloudDirectorSubnetTierLiveTest.java
+++ b/vcloud-director-portforwarding/src/test/java/brooklyn/networking/vclouddirector/VcloudDirectorSubnetTierLiveTest.java
@@ -87,11 +87,9 @@ public class VcloudDirectorSubnetTierLiveTest extends BrooklynAppLiveTestSupport
         NatMicroServiceMain.StaticRefs.service = null;
         
         super.setUp();
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwardManager.PORT_FORWARD_MANAGER_STARTING_PORT, STARTING_PORT);
-        
+        mgmt.getBrooklynProperties().put(PortForwardManager.PORT_FORWARD_MANAGER_STARTING_PORT, STARTING_PORT);
         loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
-        publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
-        
+        publicIp = checkNotNull(loc.getConfig(PortForwarderVcloudDirector.NETWORK_PUBLIC_IP), "publicip");
         executor = Executors.newCachedThreadPool();
     }
     
@@ -112,8 +110,8 @@ public class VcloudDirectorSubnetTierLiveTest extends BrooklynAppLiveTestSupport
     public void testOpenPortForwardingAndAdvertise() throws Exception {
         // TODO When production vCD NAT Microservice is upgraded to support this, then just connect to that.
         String microserviceUrl = startVcdNatMicroservice();
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_ENDPOINT, microserviceUrl);
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_AUTO_ALLOCATES_PORT, "true");
+        mgmt.getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_ENDPOINT, microserviceUrl);
+        mgmt.getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_AUTO_ALLOCATES_PORT, "true");
         
         runOpenPortForwardingAndAdvertise(null, true);
     }
@@ -131,8 +129,8 @@ public class VcloudDirectorSubnetTierLiveTest extends BrooklynAppLiveTestSupport
     public void testOpenPortForwardingAndAdvertiseWithoutCreatingVms() throws Exception {
         // TODO When production vCD NAT Microservice is upgraded to support this, then just connect to that.
         String microserviceUrl = startVcdNatMicroservice();
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_ENDPOINT, microserviceUrl);
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_AUTO_ALLOCATES_PORT, "true");
+        mgmt.getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_ENDPOINT, microserviceUrl);
+        mgmt.getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_AUTO_ALLOCATES_PORT, "true");
         
         runOpenPortForwardingAndAdvertise(null, false);
     }
@@ -142,9 +140,9 @@ public class VcloudDirectorSubnetTierLiveTest extends BrooklynAppLiveTestSupport
     public void testOpenPortForwardingAndAdvertiseUsingPortRangeOnLocationWithoutCreatingVms() throws Exception {
         // TODO When production vCD NAT Microservice is upgraded to support this, then just connect to that.
         String microserviceUrl = startVcdNatMicroservice();
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_ENDPOINT, microserviceUrl);
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_AUTO_ALLOCATES_PORT, "true");
-        ((LocalManagementContext)mgmt).getBrooklynProperties().put("brooklyn.location.named."+LOCATION_SPEC+"."+PortForwarderVcloudDirector.PORT_RANGE.getName(), 
+        mgmt.getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_ENDPOINT, microserviceUrl);
+        mgmt.getBrooklynProperties().put(PortForwarderVcloudDirector.NAT_MICROSERVICE_AUTO_ALLOCATES_PORT, "true");
+        mgmt.getBrooklynProperties().put("brooklyn.location.named."+LOCATION_SPEC+"."+PortForwarderVcloudDirector.PORT_RANGE.getName(),
                 (STARTING_PORT+5)+"-"+ENDING_PORT);
 
         // Replace the original loc, now that we've updated the port-range

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.cloudsoft.jclouds.labs</groupId>
             <artifactId>vcloud-director</artifactId>
-            <version>1.8.2-alpha-cloudsoft.8</version>
+            <version>1.9.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>io.cloudsoft.jclouds.labs</groupId>
             <artifactId>vcloud-director</artifactId>
-            <version>1.9.0-SNAPSHOT</version>
+            <version>1.9.0-rc2</version>
         </dependency>
 
         <dependency>

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
@@ -614,6 +614,9 @@ public class NatService {
                 VcloudClient.setLogLevel(logLevel);
             }
 
+            // The vcloudClient want the URI without the path.
+            // However, users of the NatMicroserviceClient may want the URI to include
+            // the vOrg in the path, because some endpoints are only accessible in that way.
             URI uri = URI.create(endpoint);
             String vCloudUrl = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
 

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
@@ -3,6 +3,7 @@ package brooklyn.networking.vclouddirector;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.net.InetAddress;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -17,15 +18,6 @@ import javax.xml.bind.JAXBElement;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import brooklyn.location.PortRange;
-import brooklyn.location.basic.PortRanges;
-import brooklyn.util.exceptions.Exceptions;
-import brooklyn.util.guava.Maybe;
-import brooklyn.util.net.Protocol;
-import brooklyn.util.text.Strings;
-import brooklyn.util.time.Duration;
-import brooklyn.util.time.Time;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
@@ -57,6 +49,15 @@ import com.vmware.vcloud.sdk.admin.extensions.ExtensionQueryService;
 import com.vmware.vcloud.sdk.admin.extensions.VcloudAdminExtension;
 import com.vmware.vcloud.sdk.constants.Version;
 import com.vmware.vcloud.sdk.constants.query.QueryReferenceType;
+
+import brooklyn.location.PortRange;
+import brooklyn.location.basic.PortRanges;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.guava.Maybe;
+import brooklyn.util.net.Protocol;
+import brooklyn.util.text.Strings;
+import brooklyn.util.time.Duration;
+import brooklyn.util.time.Time;
 
 /**
  * For adding/removing NAT rules to vcloud-director.
@@ -522,13 +523,15 @@ public class NatService {
     private void checkPublicIp(final String publicIp, List<SubnetParticipationType> subnetParticipations) {
         boolean found = false;
         for (SubnetParticipationType subnetParticipation : subnetParticipations) {
-            Iterator<IpRangeType> iter = subnetParticipation.getIpRanges().getIpRange().iterator();
-            while (!found && iter.hasNext()) {
-                IpRangeType ipRangeType = iter.next();
-                long ipLo = ipToLong(InetAddresses.forString(ipRangeType.getStartAddress()));
-                long ipHi = ipToLong(InetAddresses.forString(ipRangeType.getEndAddress()));
-                long ipToTest = ipToLong(InetAddresses.forString(publicIp));
-                found = ipToTest >= ipLo && ipToTest <= ipHi;
+            if (subnetParticipation.getIpRanges() != null) {
+                Iterator<IpRangeType> iter = subnetParticipation.getIpRanges().getIpRange().iterator();
+                while (!found && iter.hasNext()) {
+                    IpRangeType ipRangeType = iter.next();
+                    long ipLo = ipToLong(InetAddresses.forString(ipRangeType.getStartAddress()));
+                    long ipHi = ipToLong(InetAddresses.forString(ipRangeType.getEndAddress()));
+                    long ipToTest = ipToLong(InetAddresses.forString(publicIp));
+                    found = ipToTest >= ipLo && ipToTest <= ipHi;
+                }
             }
         }
         if (!found) {
@@ -610,13 +613,16 @@ public class NatService {
                 // Consider setting this to WARN; leaving as default is not explicitly set
                 VcloudClient.setLogLevel(logLevel);
             }
-            
+
+            URI uri = URI.create(endpoint);
+            String vCloudUrl = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
+
             // Client login
             VcloudClient vcloudClient = null;
             boolean versionFound = false;
             for (Version version : VCLOUD_VERSIONS) {
                 try {
-                    vcloudClient = new VcloudClient(endpoint, version);
+                    vcloudClient = new VcloudClient(vCloudUrl, version);
                     LOG.debug("VCloudClient - trying login to {} using {}", endpoint, version);
                     vcloudClient.login(identity, credential);
                     versionFound = true;

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
@@ -18,13 +18,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import brooklyn.entity.BrooklynAppLiveTestSupport;
-import brooklyn.location.PortRange;
-import brooklyn.location.basic.PortRanges;
-import brooklyn.location.jclouds.JcloudsLocation;
-import brooklyn.util.exceptions.Exceptions;
-import brooklyn.util.net.Protocol;
-
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -34,6 +27,13 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.vmware.vcloud.api.rest.schema.NatRuleType;
+
+import brooklyn.entity.BrooklynAppLiveTestSupport;
+import brooklyn.location.PortRange;
+import brooklyn.location.basic.PortRanges;
+import brooklyn.location.jclouds.JcloudsLocation;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.net.Protocol;
 
 /**
  * Tests assume that brooklyn.properties have been configured with location specs for vCHS and TAI.
@@ -61,6 +61,8 @@ public abstract class AbstractNatServiceLiveTest extends BrooklynAppLiveTestSupp
     public static final String LOCATION_SPEC = "canopy-vCHS";
 
     public static final String LOCATION_TAI_SPEC = "canopy-TAI";
+
+    public static final String LOCATION_TAI_2_SPEC = "Canopy_TAI_2";
 
     public static final String INTERNAL_MACHINE_IP = "192.168.109.10";
 

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
-import brooklyn.location.jclouds.JcloudsLocation;
-
 import com.google.common.net.HostAndPort;
 import com.vmware.vcloud.api.rest.schema.NatRuleType;
+
+import brooklyn.location.jclouds.JcloudsLocation;
 
 /**
  * Tests assume that brooklyn.properties have been configured with location specs for vCHS and TAI.
@@ -37,6 +37,17 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
     @Test(groups="Live")
     public void testGetNatRulesAtTai() throws Exception {
         JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_SPEC);
+        NatService service = newServiceBuilder(loc2)
+                .portRange(DEFAULT_PORT_RANGE)
+                .build();
+        List<NatRuleType> rules = service.getNatRules(service.getEdgeGateway());
+        assertNotNull(rules);
+    }
+
+    // TAI2.0 (as at 2015-04-27) is running vcloud-director version 5.5
+    @Test(groups="Live")
+    public void testGetNatRulesAtTai2() throws Exception {
+        JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_2_SPEC);
         NatService service = newServiceBuilder(loc2)
                 .portRange(DEFAULT_PORT_RANGE)
                 .build();


### PR DESCRIPTION
add NatServiceMicroserviceTAI2LiveTest

This requires the latest version of cloudsoft/jclouds-vcloud-director to properly test

Also it requires a NAT microservice instance started with something like

`./start.sh  launch --endpointsProperties ~/.brooklyn/dnat-microservice.properties` where the `dnat-microservice.properties` contains the new endpoint for TAI2.0