### PR TITLE
NAT microservice: improve locking granularity

### DIFF
--- a/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/api/NatServiceApi.java
+++ b/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/api/NatServiceApi.java
@@ -49,6 +49,9 @@ public interface NatServiceApi {
             @ApiParam(name = "endpoint", value = "Cloud endpoint URL", required = true)
             @QueryParam("endpoint") String endpoint,
 
+            @ApiParam(name = "vdc", value = "vDC name", required = false)
+            @QueryParam("vdc") String vDC,
+
             @ApiParam(name = "identity", value = "User identity", required = true)
             @QueryParam("identity") String identity,
 
@@ -66,6 +69,9 @@ public interface NatServiceApi {
     public String openPortForwarding(
             @ApiParam(name = "endpoint", value = "Cloud endpoint URL", required = true)
             @QueryParam("endpoint") String endpoint,
+
+            @ApiParam(name = "vdc", value = "vDC name", required = false)
+            @QueryParam("vdc") String vDC,
 
             @ApiParam(name = "identity", value = "User identity", required = true)
             @QueryParam("identity") String identity,
@@ -96,6 +102,9 @@ public interface NatServiceApi {
     public Response closePortForwarding(
             @ApiParam(name = "endpoint", value = "Cloud endpoint URL", required = true)
             @QueryParam("endpoint") String endpoint,
+
+            @ApiParam(name = "vdc", value = "vDC name", required = false)
+            @QueryParam("vdc") String vDC,
 
             @ApiParam(name = "identity", value = "User identity", required = true)
             @QueryParam("identity") String identity,

--- a/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/resources/NatServiceResource.java
+++ b/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/resources/NatServiceResource.java
@@ -45,10 +45,10 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
     private static final Logger LOG = LoggerFactory.getLogger(NatServiceResource.class);
 
     @Override
-    public List<NatRuleSummary> list(String endpoint, String identity, String credential) {
+    public List<NatRuleSummary> list(String endpoint, String vDC, String identity, String credential) {
         try {
             LOG.info("listing nat rules on " + endpoint);
-            List<NatRuleType> rules = dispatcher().getNatRules(endpoint, identity, credential);
+            List<NatRuleType> rules = dispatcher().getNatRules(endpoint, vDC, identity, credential);
             return FluentIterable
                     .from(rules)
                     .transform(new Function<NatRuleType, NatRuleSummary>() {
@@ -64,7 +64,7 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
     }
 
     @Override
-    public String openPortForwarding(String endpoint,
+    public String openPortForwarding(String endpoint, String vDC,
             String identity, String credential, String protocol,
             String original, String originalPortRange, String translated) {
         LOG.info("creating nat rule {} -> {} for {}", new Object[]{original, translated, protocol});
@@ -72,7 +72,7 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
         HostAndPort translatedHostAndPort = HostAndPort.fromString(translated);
         Preconditions.checkArgument(translatedHostAndPort.hasPort(), "translated %s must include port", translated);
         try {
-            HostAndPort result = dispatcher().openPortForwarding(endpoint, identity, credential, new PortForwardingConfig()
+            HostAndPort result = dispatcher().openPortForwarding(endpoint, vDC, identity, credential, new PortForwardingConfig()
                     .protocol(Protocol.valueOf(protocol.toUpperCase()))
                     .publicEndpoint(originalHostAndPort)
                     .publicPortRange(Strings.isBlank(originalPortRange) ? null : PortRanges.fromString(originalPortRange))
@@ -86,8 +86,8 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
 
     @Override
     public Response closePortForwarding(String endpoint,
-            String identity, String credential, String protocol,
-            String original, String translated) {
+            String vDC, String identity, String credential,
+            String protocol, String original, String translated) {
         LOG.info("deleting nat rule {} -> {} for {}", new Object[]{original, translated, protocol});
         // TODO throw 404 if not found
         HostAndPort originalHostAndPort = HostAndPort.fromString(original);
@@ -95,7 +95,7 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
         Preconditions.checkArgument(originalHostAndPort.hasPort(), "original %s must include port", original);
         Preconditions.checkArgument(translatedHostAndPort.hasPort(), "translated %s must include port", translated);
         try {
-            dispatcher().closePortForwarding(endpoint, identity, credential, new PortForwardingConfig()
+            dispatcher().closePortForwarding(endpoint, vDC, identity, credential, new PortForwardingConfig()
                     .protocol(Protocol.valueOf(protocol.toUpperCase()))
                     .publicEndpoint(originalHostAndPort)
                     .targetEndpoint(translatedHostAndPort));

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
@@ -51,6 +51,7 @@ public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRes
     private LocalManagementContext mgmt;
     private JcloudsLocation loc;
     private String endpoint;
+    private String vDC;
     private String identity;
     private String credential;
     private String publicIp;
@@ -66,6 +67,7 @@ public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRes
         mgmt = new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
         loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(getLocationSpec());
         endpoint = endpoint(loc);
+        vDC = loc.getRegion();
         identity = loc.getIdentity();
         credential = loc.getCredential();
         publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
@@ -126,6 +128,7 @@ public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRes
         // Open the NAT rule
         String openUrl = "/v1/nat"
                 + "?endpoint="+escaper.escape(endpoint)
+                + (vDC != null ? "?vdc="+escaper.escape(vDC) : "")
                 + "&identity="+escaper.escape(identity)
                 + "&credential="+escaper.escape(credential)
                 + "&protocol=" + protocol
@@ -154,6 +157,7 @@ public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRes
             // Delete the rule
             String deleteUrl = "/v1/nat"
                     + "?endpoint="+escaper.escape(endpoint)
+                    + (vDC != null ? "?vdc="+escaper.escape(vDC) : "")
                     + "&identity="+escaper.escape(identity)
                     + "&credential="+escaper.escape(credential)
                     + "&protocol=" + protocol
@@ -167,7 +171,7 @@ public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRes
             assertRuleNotExists(result, targetEndpoint, protocol);
         } finally {
             if (result != null) {
-                dispatcher.closePortForwarding(endpoint, identity, credential, new PortForwardingConfig()
+                dispatcher.closePortForwarding(endpoint, vDC, identity, credential, new PortForwardingConfig()
                         .protocol(Protocol.TCP)
                         .publicEndpoint(result)
                         .targetEndpoint(targetEndpoint));

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
@@ -19,6 +19,15 @@ import javax.xml.bind.JAXBElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import brooklyn.location.PortRange;
+import brooklyn.location.basic.PortRanges;
+import brooklyn.util.exceptions.Exceptions;
+import brooklyn.util.guava.Maybe;
+import brooklyn.util.net.Protocol;
+import brooklyn.util.text.Strings;
+import brooklyn.util.time.Duration;
+import brooklyn.util.time.Time;
+
 import com.google.common.annotations.Beta;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicates;
@@ -50,15 +59,6 @@ import com.vmware.vcloud.sdk.admin.extensions.VcloudAdminExtension;
 import com.vmware.vcloud.sdk.constants.Version;
 import com.vmware.vcloud.sdk.constants.query.QueryReferenceType;
 
-import brooklyn.location.PortRange;
-import brooklyn.location.basic.PortRanges;
-import brooklyn.util.exceptions.Exceptions;
-import brooklyn.util.guava.Maybe;
-import brooklyn.util.net.Protocol;
-import brooklyn.util.text.Strings;
-import brooklyn.util.time.Duration;
-import brooklyn.util.time.Time;
-
 /**
  * For adding/removing NAT rules to vcloud-director.
  * 
@@ -81,9 +81,15 @@ public class NatService {
     private static final List<Version> VCLOUD_VERSIONS = ImmutableList.of(Version.V5_5, Version.V5_1, Version.V1_5);
 
     public static Builder builder() {
-        return new Builder();
+        return new NatServiceFactory().builder();
     }
 
+    public static class NatServiceFactory {
+        public Builder builder() {
+            return new Builder();
+        }
+    }
+    
     public static class Builder {
         private String identity;
         private String credential;
@@ -124,8 +130,8 @@ public class NatService {
     }
     
     public static class Delta {
-        private final List<PortForwardingConfig> toOpen = Lists.newArrayList();
-        private final List<PortForwardingConfig> toClose = Lists.newArrayList();
+        protected final List<PortForwardingConfig> toOpen = Lists.newArrayList();
+        protected final List<PortForwardingConfig> toClose = Lists.newArrayList();
         
         public Delta() {
         }
@@ -169,10 +175,10 @@ public class NatService {
         
         public UpdateResult() {
         }
-        private UpdateResult opened(PortForwardingConfig req, PortForwardingConfig val) {
+        protected UpdateResult opened(PortForwardingConfig req, PortForwardingConfig val) {
             opened.put(req, val); return this;
         }
-        private UpdateResult closed(PortForwardingConfig req, PortForwardingConfig val) {
+        protected UpdateResult closed(PortForwardingConfig req, PortForwardingConfig val) {
             closed.put(req, val); return this;
         }
         public Map<PortForwardingConfig, PortForwardingConfig> getOpened() {

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceDispatcherLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceDispatcherLiveTest.java
@@ -3,6 +3,7 @@ package brooklyn.networking.vclouddirector;
 import java.net.URI;
 
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import brooklyn.networking.vclouddirector.NatServiceDispatcher.EndpointConfig;
 
@@ -20,9 +21,11 @@ import com.google.common.net.HostAndPort;
  * brooklyn.location.named.canopy-vCHS.advancednetworking.vcloud.network.publicip=23.92.230.21
  * </pre> 
  */
+@Test(groups="Live")
 public class NatServiceDispatcherLiveTest extends AbstractNatServiceLiveTest {
 
     private String endpoint;
+    private String vDC;
     private String identity;
     private String credential;
     
@@ -34,6 +37,7 @@ public class NatServiceDispatcherLiveTest extends AbstractNatServiceLiveTest {
         super.setUp();
         URI uri = URI.create(loc.getEndpoint());
         endpoint = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), null, null, null).toString();
+        vDC = loc.getRegion();
         identity = loc.getIdentity();
         credential = loc.getCredential();
         
@@ -44,10 +48,10 @@ public class NatServiceDispatcherLiveTest extends AbstractNatServiceLiveTest {
     }
     
     protected HostAndPort openPortForwarding(PortForwardingConfig config) throws Exception {
-        return dispatcher.openPortForwarding(endpoint, identity, credential, config);
+        return dispatcher.openPortForwarding(endpoint, vDC, identity, credential, config);
     }
     
     protected HostAndPort closePortForwarding(PortForwardingConfig config) throws Exception {
-        return dispatcher.closePortForwarding(endpoint, identity, credential, config);
+        return dispatcher.closePortForwarding(endpoint, vDC, identity, credential, config);
     }
 }

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceDispatcherTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceDispatcherTest.java
@@ -1,0 +1,230 @@
+package brooklyn.networking.vclouddirector;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import brooklyn.location.PortRange;
+import brooklyn.networking.vclouddirector.NatService.Builder;
+import brooklyn.networking.vclouddirector.NatServiceDispatcher.EndpointConfig;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.net.HostAndPort;
+import com.vmware.vcloud.api.rest.schema.NatRuleType;
+import com.vmware.vcloud.sdk.VCloudException;
+import com.vmware.vcloud.sdk.VcloudClient;
+
+public class NatServiceDispatcherTest {
+
+    private Map<String, EndpointConfig> endpoints = ImmutableMap.of(
+            "http://127.0.0.1:1234", new EndpointConfig(null, null, null),
+            "http://127.0.0.1:1235", new EndpointConfig(null, null, null),
+            "http://127.0.0.1:1236", new EndpointConfig(null, null, null));
+    
+    private RecordingNatServiceFactory natServiceFactory;
+    private NatServiceDispatcher dispatcher;
+    
+    @BeforeMethod(alwaysRun=true)
+    public void setUp() throws Exception {
+        natServiceFactory = new RecordingNatServiceFactory();
+        
+        dispatcher = NatServiceDispatcher.builder()
+                .natServiceFactory(natServiceFactory)
+                .endpoints(endpoints)
+                .build();
+    }
+
+    @Test
+    public void testSameVdcGetsSameMutex() throws Exception {
+        String endpoint = Iterables.getFirst(endpoints.keySet(), null);
+        for (int i = 0; i < 3; i++) {
+            dispatcher.openPortForwarding(endpoint, "myvdc", "myid"+i+"@myorg", "mycred"+i, new PortForwardingConfig()
+                    .targetEndpoint(HostAndPort.fromParts("myhost", 1234+i))
+                    .publicEndpoint(HostAndPort.fromHost("requestedpublichost")));
+        }
+        
+        assertEquals(getMutexCount(), 1);
+    }
+
+    @Test
+    public void testSameVorgWithNullVdcGetsSameMutex() throws Exception {
+        String endpoint = Iterables.getFirst(endpoints.keySet(), null);
+        for (int i = 0; i < 3; i++) {
+            dispatcher.openPortForwarding(endpoint, null, "myid"+i+"@myorg", "mycred"+i, new PortForwardingConfig()
+                    .targetEndpoint(HostAndPort.fromParts("myhost", 1234+i))
+                    .publicEndpoint(HostAndPort.fromHost("requestedpublichost")));
+        }
+        
+        assertEquals(getMutexCount(), 1);
+    }
+
+    @Test
+    public void testDifferentEndpointsHaveDifferentMutexes() throws Exception {
+        String vDC = null;
+        int port = 1234;
+        for (String endpoint : endpoints.keySet()) {
+            dispatcher.openPortForwarding(endpoint, vDC, "myid@myorg", "mycred", new PortForwardingConfig()
+                    .targetEndpoint(HostAndPort.fromParts("myhost", port++))
+                    .publicEndpoint(HostAndPort.fromHost("requestedpublichost")));
+        }
+        
+        assertEquals(getMutexCount(), endpoints.size());
+    }
+    
+    @Test
+    public void testDifferentVdcsHaveDifferentMutexes() throws Exception {
+        String endpoint = Iterables.getFirst(endpoints.keySet(), null);
+        for (int i = 0; i < 3; i++) {
+            dispatcher.openPortForwarding(endpoint, "myvdc-"+i, "myid@myorg", "mycred", new PortForwardingConfig()
+                    .targetEndpoint(HostAndPort.fromParts("myhost", 1234+i))
+                    .publicEndpoint(HostAndPort.fromHost("requestedpublichost")));
+        }
+        
+        assertEquals(getMutexCount(), endpoints.size());
+    }
+
+    @Test
+    public void testDifferentVorgsHaveDifferentMutexes() throws Exception {
+        String endpoint = Iterables.getFirst(endpoints.keySet(), null);
+        for (int i = 0; i < 3; i++) {
+            dispatcher.openPortForwarding(endpoint, null, "myid@myorg"+i, "mycred", new PortForwardingConfig()
+                    .targetEndpoint(HostAndPort.fromParts("myhost", 1234+i))
+                    .publicEndpoint(HostAndPort.fromHost("requestedpublichost")));
+        }
+        
+        assertEquals(getMutexCount(), endpoints.size());
+    }
+
+    private int getMutexCount() {
+        Set<Object> mutexes = Sets.newLinkedHashSet();
+        for (RecordingNatService service : natServiceFactory.services.values()) {
+            mutexes.add(service.getMutex());
+        }
+        return mutexes.size();
+    }
+    
+    
+    ///////////////////////////////////////////////////////////////////////////////////////
+    // Plumbing below to intercept NatService calls, returning plausible looking results //
+    ///////////////////////////////////////////////////////////////////////////////////////
+    
+    public static class RecordingNatServiceFactory extends NatService.NatServiceFactory {
+        public final Map<RecordingNatServiceBuilder, RecordingNatService> services = Maps.newConcurrentMap();
+        
+        public class RecordingNatServiceBuilder extends NatService.Builder {
+            @Override
+            public NatService build() {
+                RecordingNatService result = new RecordingNatService(this);
+                services.put(this, result);
+                return result;
+            }
+        }
+
+        @Override
+        public Builder builder() {
+            return new RecordingNatServiceBuilder();
+        }
+    }
+    
+    // TODO Better to use Mockito?!
+    public static class RecordingNatService extends NatService {
+        public final Builder builder;
+        int nextPort = 1024;
+        
+        public RecordingNatService(Builder builder) {
+            super(builder);
+            this.builder = builder;
+        }
+
+        @Override
+        protected VcloudClient newVcloudClient() {
+            return null;
+        }
+
+        @Override
+        protected VcloudClient newVcloudClient(String endpoint, String identity, String credential, String trustStore, String trustStorePassword, Level logLevel) {
+            return null;
+        }
+        
+        @Override
+        public List<NatRuleType> getNatRules() throws VCloudException {
+            return ImmutableList.of();
+        }
+
+        @Override
+        public HostAndPort openPortForwarding(PortForwardingConfig args) throws VCloudException {
+            return openPortForwarding(ImmutableList.of(args)).get(0);
+        }
+        
+        @Override
+        public List<HostAndPort> openPortForwarding(Iterable<PortForwardingConfig> args) throws VCloudException {
+            List<HostAndPort> result = Lists.newArrayList();
+            for (PortForwardingConfig arg : args) {
+                result.add(HostAndPort.fromParts("mypublichost", nextPort++));
+            }
+            return result;
+        }
+
+        @Override
+        public HostAndPort closePortForwarding(PortForwardingConfig args) throws VCloudException {
+            return closePortForwarding(ImmutableList.of(args)).get(0);
+        }
+        
+        @Override
+        public List<HostAndPort> closePortForwarding(Iterable<PortForwardingConfig> args) throws VCloudException {
+            List<HostAndPort> result = Lists.newArrayList();
+            for (PortForwardingConfig arg : args) {
+                result.add(HostAndPort.fromParts("mypublichost", 60000));
+            }
+            return result;
+        }
+        
+        @Override
+        public UpdateResult updatePortForwarding(Delta delta) throws VCloudException {
+            UpdateResult result = new UpdateResult();
+            for (PortForwardingConfig arg : delta.toOpen) {
+                PortForwardingConfig opened = new PortForwardingConfig()
+                        .protocol(arg.protocol)
+                        .publicEndpoint(arg.publicEndpoint == null 
+                                ? HostAndPort.fromParts("mypublichost", (nextPort++)) 
+                                : arg.publicEndpoint.hasPort() 
+                                        ? arg.publicEndpoint 
+                                        : HostAndPort.fromParts(arg.publicEndpoint.getHostText(), nextPort++))
+                        .targetEndpoint(arg.targetEndpoint);
+                result.opened(arg, opened);
+            }
+            for (PortForwardingConfig arg : delta.toClose) {
+                result.closed(arg, arg);
+            }
+            return result;
+        }
+
+        @Override
+        public Set<Integer> getUsedPublicPorts(Iterable<NatRuleType> existingRules) {
+            return ImmutableSet.<Integer>of();
+        }
+        
+        @Override
+        public int findAvailablePort(PortRange portRange, Collection<Integer> usedPorts) {
+            throw new UnsupportedOperationException();
+        }
+        
+        @Override
+        public void enableNatService() throws VCloudException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
- Allow concurrent operations if acting on different
  endpoint or vOrg or vDC
- Pass vDC through REST api (optional parameter)
- Unit test for locking in NatServiceDispatcherTest