### PR TITLE
Fix: nat microservice multiple vdcs

### DIFF
--- a/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/resources/NatServiceResource.java
+++ b/vcloud-director-nat-microservice/src/main/java/brooklyn/networking/vclouddirector/natservice/resources/NatServiceResource.java
@@ -47,7 +47,7 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
     @Override
     public List<NatRuleSummary> list(String endpoint, String vDC, String identity, String credential) {
         try {
-            LOG.info("listing nat rules on " + endpoint);
+            LOG.info("listing nat rule on {} @ {} (vDC {})", new Object[]{identity, endpoint, vDC});
             List<NatRuleType> rules = dispatcher().getNatRules(endpoint, vDC, identity, credential);
             return FluentIterable
                     .from(rules)
@@ -67,7 +67,7 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
     public String openPortForwarding(String endpoint, String vDC,
             String identity, String credential, String protocol,
             String original, String originalPortRange, String translated) {
-        LOG.info("creating nat rule {} -> {} for {}", new Object[]{original, translated, protocol});
+        LOG.info("creating nat rule {} {} -> {}, on {} @ {} (vDC {})", new Object[]{protocol, original, translated, identity, endpoint, vDC});
         HostAndPort originalHostAndPort = HostAndPort.fromString(original);
         HostAndPort translatedHostAndPort = HostAndPort.fromString(translated);
         Preconditions.checkArgument(translatedHostAndPort.hasPort(), "translated %s must include port", translated);
@@ -88,7 +88,7 @@ public class NatServiceResource extends AbstractRestResource implements NatServi
     public Response closePortForwarding(String endpoint,
             String vDC, String identity, String credential,
             String protocol, String original, String translated) {
-        LOG.info("deleting nat rule {} -> {} for {}", new Object[]{original, translated, protocol});
+        LOG.info("deleting nat rule {} {} -> {}, on {} @ {} (vDC {})", new Object[]{protocol, original, translated, identity, endpoint, vDC});
         // TODO throw 404 if not found
         HostAndPort originalHostAndPort = HostAndPort.fromString(original);
         HostAndPort translatedHostAndPort = HostAndPort.fromString(translated);

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatDirectClient.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatDirectClient.java
@@ -50,9 +50,11 @@ public class NatDirectClient implements NatClient {
         checkArgument(identity.contains("@"), "identity %s does not contain vOrg, in location %s", identity, loc);
         String vOrg = identity.substring(identity.lastIndexOf("@") + 1);
         String endpoint = transformEndpoint(loc.getEndpoint(), vOrg);
+        String vDC = loc.getRegion();
 
         client = NatService.builder()
                 .endpoint(endpoint)
+                .vDC(vDC)
                 .identity(identity)
                 .credential(credential)
                 .mutex(MutexRegistry.INSTANCE.getMutexFor(endpoint))

--- a/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatMicroserviceClient.java
+++ b/vcloud-director-portforwarding/src/main/java/brooklyn/networking/vclouddirector/NatMicroserviceClient.java
@@ -13,6 +13,7 @@ import brooklyn.location.jclouds.JcloudsLocation;
 import brooklyn.util.http.HttpTool;
 import brooklyn.util.http.HttpToolResponse;
 import brooklyn.util.net.Urls;
+import brooklyn.util.text.Strings;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Splitter;
@@ -43,13 +44,16 @@ public class NatMicroserviceClient implements NatClient {
     
     private final String microserviceUri;
     private final String endpoint; // e.g. "https://p5v1-vcd.vchs.vmware.com:443";
+    private final String vDC;
     private final String credential;
     private final String identity;
+
 
     public NatMicroserviceClient(String microserviceUri, JcloudsLocation loc) {
         this.microserviceUri = checkNotNull(microserviceUri, "microserviceUri");
         this.identity = checkNotNull(loc.getIdentity(), "identity");
         this.credential = checkNotNull(loc.getCredential(), "credential");
+        this.vDC = loc.getRegion();
         
         checkArgument(identity.contains("@"), "identity %s does not contain vOrg, in location %s", identity, loc);
         String vOrg = identity.substring(identity.lastIndexOf("@") + 1);
@@ -66,6 +70,7 @@ public class NatMicroserviceClient implements NatClient {
         Escaper escaper = UrlEscapers.urlPathSegmentEscaper();
         URI uri = URI.create(Urls.mergePaths(microserviceUri, "/v1/nat"
                 + "?endpoint="+escaper.escape(endpoint)
+                + (Strings.isNonBlank(vDC) ? "&vdc="+escaper.escape(vDC) : "")
                 + "&identity="+escaper.escape(identity)
                 + "&credential="+escaper.escape(credential)
                 + "&protocol=" + args.protocol
@@ -92,6 +97,7 @@ public class NatMicroserviceClient implements NatClient {
         Escaper escaper = UrlEscapers.urlPathSegmentEscaper();
         URI uri = URI.create(Urls.mergePaths(microserviceUri, "/v1/nat"
                 + "?endpoint="+escaper.escape(endpoint)
+                + (Strings.isNonBlank(vDC) ? "&vdc="+escaper.escape(vDC) : "")
                 + "&identity="+escaper.escape(identity)
                 + "&credential="+escaper.escape(credential)
                 + "&protocol=" + args.protocol

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatService.java
@@ -94,6 +94,7 @@ public class NatService {
         private String identity;
         private String credential;
         private String endpoint;
+        private String vDC;
         private String trustStore;
         private String trustStorePassword;
         private PortRange portRange = PortRanges.ANY_HIGH_PORT;
@@ -108,6 +109,9 @@ public class NatService {
         }
         public Builder endpoint(String val) {
             this.endpoint = checkNotNull(val, "endpoint"); return this;
+        }
+        public Builder vDC(@Nullable String val) {
+            this.vDC = val; return this;
         }
         public Builder trustStore(String val) {
             this.trustStore = val; return this;
@@ -193,6 +197,7 @@ public class NatService {
     }
 
     private final String baseUrl; // e.g. "https://p5v1-vcd.vchs.vmware.com:443";
+    @Nullable private final String vDC;
     private final String credential;
     private final String identity;
     private final String trustStore;
@@ -205,6 +210,7 @@ public class NatService {
 
     public NatService(Builder builder) {
         baseUrl = checkNotNull(builder.endpoint, "endpoint");
+        vDC = builder.vDC;
         identity = checkNotNull(builder.identity, "identity");
         credential = checkNotNull(builder.credential, "credential");
         trustStore = builder.trustStore;

--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatServiceDispatcher.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatServiceDispatcher.java
@@ -429,6 +429,7 @@ public class NatServiceDispatcher {
                         .identity(creds.identity)
                         .credential(creds.credential)
                         .endpoint(creds.endpoint)
+                        .vDC(creds.vDC)
                         .trustStore(endpointConfig.trustStore)
                         .trustStorePassword(endpointConfig.trustStorePassword)
                         .portRange(portRange)

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
@@ -67,9 +67,16 @@ public abstract class AbstractNatServiceLiveTest extends BrooklynAppLiveTestSupp
 
     public static final String LOCATION_TAI_2_SPEC = "Canopy_TAI_2";
 
+    // A second vDC in a vOrg within TAI 2.0
+    public static final String LOCATION_TAI_2b_SPEC = "Canopy_TAI_2b";
+
     public static final String LOCATION_SPEC = LOCATION_TAI_SPEC;
 
     public static final String INTERNAL_MACHINE_IP = "192.168.109.10";
+
+    public static final String INTERNAL_MACHINE_IP_TAI_2 = "192.168.10.110"; // IP within TAI 2.0's first vDC
+
+    public static final String INTERNAL_MACHINE_IP_TAI_2b = "192.168.11.110"; // IP within TAI 2.0's second vDC
 
     public static final int STARTING_PORT = 19980;
     public static final PortRange DEFAULT_PORT_RANGE = PortRanges.fromString("19980-19999");
@@ -229,7 +236,7 @@ public abstract class AbstractNatServiceLiveTest extends BrooklynAppLiveTestSupp
     
     protected void assertRuleExists(HostAndPort expectedPublicEndpoint, HostAndPort targetEndpoint) throws Exception {
         NatService service = newServiceBuilder(loc).build();
-        List<NatRuleType> rules = service.getNatRules(service.getEdgeGateway());
+        List<NatRuleType> rules = service.getNatRules();
         NatRuleType rule = Iterables.tryFind(rules, NatPredicates.translatedEndpointEquals(targetEndpoint)).get();
         
         assertEquals(rule.getGatewayNatRule().getOriginalIp(), expectedPublicEndpoint.getHostText());
@@ -240,7 +247,7 @@ public abstract class AbstractNatServiceLiveTest extends BrooklynAppLiveTestSupp
     
     protected void assertRuleNotExists(HostAndPort publicEndpoint, HostAndPort targetEndpoint, Protocol protocol) throws Exception {
         NatService service = newServiceBuilder(loc).build();
-        List<NatRuleType> rules = service.getNatRules(service.getEdgeGateway());
+        List<NatRuleType> rules = service.getNatRules();
         Optional<NatRuleType> rule = Iterables.tryFind(rules, NatPredicates.translatedEndpointEquals(targetEndpoint));
         assertFalse(rule.isPresent(), (rule.isPresent() ? toString(rule.get()) : rule.toString()));
     }

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
@@ -1,15 +1,19 @@
 package brooklyn.networking.vclouddirector;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.testng.Assert.assertNotNull;
 
 import java.util.List;
 
 import org.testng.annotations.Test;
 
+import brooklyn.location.PortRange;
+import brooklyn.location.basic.PortRanges;
+import brooklyn.location.jclouds.JcloudsLocation;
+import brooklyn.util.net.Protocol;
+
 import com.google.common.net.HostAndPort;
 import com.vmware.vcloud.api.rest.schema.NatRuleType;
-
-import brooklyn.location.jclouds.JcloudsLocation;
 
 /**
  * Tests assume that brooklyn.properties have been configured with location specs for vCHS and TAI.
@@ -40,7 +44,7 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
         NatService service = newServiceBuilder(loc2)
                 .portRange(DEFAULT_PORT_RANGE)
                 .build();
-        List<NatRuleType> rules = service.getNatRules(service.getEdgeGateway());
+        List<NatRuleType> rules = service.getNatRules();
         assertNotNull(rules);
     }
 
@@ -51,7 +55,19 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
         NatService service = newServiceBuilder(loc2)
                 .portRange(DEFAULT_PORT_RANGE)
                 .build();
-        List<NatRuleType> rules = service.getNatRules(service.getEdgeGateway());
+        List<NatRuleType> rules = service.getNatRules();
+        assertNotNull(rules);
+    }
+
+    // The second vDC within a vOrg.
+    // TAI2.0 (as at 2015-04-27) is running vcloud-director version 5.5
+    @Test(groups="Live")
+    public void testGetNatRulesAtTai2b() throws Exception {
+        JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_2b_SPEC);
+        NatService service = newServiceBuilder(loc2)
+                .portRange(DEFAULT_PORT_RANGE)
+                .build();
+        List<NatRuleType> rules = service.getNatRules();
         assertNotNull(rules);
     }
     
@@ -59,9 +75,68 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
     @Test(groups="Live")
     public void testGetNatRules() throws Exception {
         NatService service = newServiceBuilder(loc).build();
-        List<NatRuleType> rules = service.getNatRules(service.getEdgeGateway());
+        List<NatRuleType> rules = service.getNatRules();
         assertNotNull(rules);
     }
+    
+    @Test(groups="Live")
+    public void testAddNatRuleAtTai2() throws Exception {
+        JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_2_SPEC);
+        String publicIp2 = (String) checkNotNull(loc2.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+
+        HostAndPort targetEndpoint = HostAndPort.fromParts(INTERNAL_MACHINE_IP_TAI_2, 1);
+        HostAndPort publicEndpoint = HostAndPort.fromString(publicIp2);
+        PortRange publicPortRange = PortRanges.fromString(STARTING_PORT+"-"+(STARTING_PORT+10));
+        HostAndPort actualEndpoint = null;
+        try {
+            actualEndpoint = openPortForwarding(loc2, new PortForwardingConfig()
+                    .protocol(Protocol.TCP)
+                    .publicEndpoint(publicEndpoint)
+                    .publicPortRange(publicPortRange)
+                    .targetEndpoint(targetEndpoint));
+            
+            assertRuleExists(actualEndpoint, targetEndpoint);
+            
+        } finally {
+            if (actualEndpoint != null) {
+                closePortForwarding(loc2, new PortForwardingConfig()
+                        .protocol(Protocol.TCP)
+                        .publicEndpoint(actualEndpoint)
+                        .targetEndpoint(targetEndpoint));
+                assertRuleNotExists(actualEndpoint, targetEndpoint, Protocol.TCP);
+            }
+        }
+    }
+
+    @Test(groups="Live")
+    public void testAddNatRuleAtTai2b() throws Exception {
+        JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_2b_SPEC);
+        String publicIp2 = (String) checkNotNull(loc2.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+
+        HostAndPort targetEndpoint = HostAndPort.fromParts(INTERNAL_MACHINE_IP_TAI_2b, 1);
+        HostAndPort publicEndpoint = HostAndPort.fromString(publicIp2);
+        PortRange publicPortRange = PortRanges.fromString(STARTING_PORT+"-"+(STARTING_PORT+10));
+        HostAndPort actualEndpoint = null;
+        try {
+            actualEndpoint = openPortForwarding(loc2, new PortForwardingConfig()
+                    .protocol(Protocol.TCP)
+                    .publicEndpoint(publicEndpoint)
+                    .publicPortRange(publicPortRange)
+                    .targetEndpoint(targetEndpoint));
+            
+            assertRuleExists(actualEndpoint, targetEndpoint);
+            
+        } finally {
+            if (actualEndpoint != null) {
+                closePortForwarding(loc2, new PortForwardingConfig()
+                        .protocol(Protocol.TCP)
+                        .publicEndpoint(actualEndpoint)
+                        .targetEndpoint(targetEndpoint));
+                assertRuleNotExists(actualEndpoint, targetEndpoint, Protocol.TCP);
+            }
+        }
+    }
+
 
     @Test(groups="Live")
     public void testAddNatRulesConcurrently() throws Exception {
@@ -72,14 +147,22 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
             sharedMutex = null;
         }
     }
-    
+
     protected HostAndPort openPortForwarding(PortForwardingConfig config) throws Exception {
+        return openPortForwarding(loc, config);
+    }
+
+    protected HostAndPort closePortForwarding(PortForwardingConfig config) throws Exception {
+        return closePortForwarding(loc, config);
+    }
+    
+    protected HostAndPort openPortForwarding(JcloudsLocation loc, PortForwardingConfig config) throws Exception {
         Object mutex = (sharedMutex == null) ? new Object() : sharedMutex;
         NatService service = newServiceBuilder(loc).mutex(mutex).build();
         return service.openPortForwarding(config);
     }
     
-    protected HostAndPort closePortForwarding(PortForwardingConfig config) throws Exception {
+    protected HostAndPort closePortForwarding(JcloudsLocation loc, PortForwardingConfig config) throws Exception {
         Object mutex = (sharedMutex == null) ? new Object() : sharedMutex;
         NatService service = newServiceBuilder(loc).mutex(mutex).build();
         return service.closePortForwarding(config);


### PR DESCRIPTION
handle multiple EdgeGateways
    
If a vOrg has multiple vDC then it will have multiple EdgeGateways. We can’t just get the first, as that might be for the wrong vDC. Therefore find the right one (i.e. the one that has the required public ips).
    
Also handle there being multiple Gateway Interfaces of type “uplink” in an EdgeGateway - find the one with the public ips, rather than just picking the last one.
