### PR TITLE
NAT microservice config: endpoint case-insensitive

### DIFF
--- a/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatServiceDispatcher.java
+++ b/vcloud-director/src/main/java/brooklyn/networking/vclouddirector/NatServiceDispatcher.java
@@ -447,11 +447,13 @@ public class NatServiceDispatcher {
     }
     
     protected EndpointConfig getEndpointConfig(String endpoint) {
+        String endpointLower = endpoint.toLowerCase();
         for (String contender : endpoints.keySet()) {
-            if (endpoint.startsWith(contender)) {
-                return endpoints.get(contender);
+            String contenderLower = contender.toLowerCase();
+            if (endpointLower.startsWith(contenderLower)) {
+                return endpoints.get(contenderLower);
             }
-            if (contender.endsWith("/") && endpoint.startsWith(contender.substring(0, contender.length()-1))) {
+            if (contenderLower.endsWith("/") && endpointLower.startsWith(contenderLower.substring(0, contenderLower.length()-1))) {
                 return endpoints.get(contender);
             }
         }


### PR DESCRIPTION
- A customer hit an error where their URL used different case from 
  that in the microservice’s config file. It therefore did not match
  and failed.
- Now do a case-insensitive comparison of the endpoint + vOrg.