### PR TITLE
0.7.0 version markers (against 0.7.x branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test-output
 .idea/
 *.iml
 .DS_Store
+ignored

--- a/cloudstack/pom.xml
+++ b/cloudstack/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <groupId>io.brooklyn.networking</groupId>
     <artifactId>brooklyn-networking-parent</artifactId>
     <packaging>pom</packaging>
+    <version>0.7.0-SNAPSHOT</version>  <!-- ADVANCED_NETWORKING_VERSION -->
 
     <name>Brooklyn Advanced Networking</name>
     <description>
@@ -36,7 +37,7 @@
     </parent>
 
     <properties>
-        <brooklyn.version>0.7.0-SNAPSHOT</brooklyn.version> <!--  BROOKLYN_VERSION -->
+        <brooklyn.version>0.7.0-SNAPSHOT</brooklyn.version> <!-- BROOKLYN_VERSION -->
         <jclouds.groupId>org.apache.jclouds</jclouds.groupId>
     </properties>
 

--- a/portforwarding/pom.xml
+++ b/portforwarding/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scripts/change-version.sh
+++ b/scripts/change-version.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+# changes the version everywhere
+# usage, e.g.:  change-version.sh 0.3.0-SNAPSHOT 0.3.0-RC1
+#          or:  change-version.sh MARKER 0.3.0-SNAPSHOT 0.3.0-RC1
+
+[ -d .git ] || {
+  echo "Must run in brooklyn project root directory"
+  exit 1
+}
+
+if [ "$#" -eq 2 ]; then
+  VERSION_MARKER=BROOKLYN_VERSION
+elif [ "$#" -eq 3 ]; then
+  VERSION_MARKER=$1_VERSION
+  shift;
+else
+  echo "Usage:  "$0" [VERSION_MARKER] CURRENT_VERSION NEW_VERSION"
+  echo " e.g.:  "$0" BROOKLYN 0.3.0-SNAPSHOT 0.3.0-RC1"
+  exit 1
+fi
+
+# remove binaries and stuff
+if [ -f pom.xml ] && [ -d target ] ; then mvn clean ; fi
+
+VERSION_MARKER_NL=${VERSION_MARKER}_BELOW
+CURRENT_VERSION=$1
+NEW_VERSION=$2
+
+# grep --exclude-dir working only in recent versions, not on all platforms, replace with find;
+# skip folders named "ignored" or .xxx (but not the current folder ".");
+# exclude log, war, etc. files;
+# use null delimiters so files containing spaces are supported;
+# pass /dev/null as the first file to search in, so the command doesn't fail if find doesn't match any files;
+# add || true for the case where grep doesn't have matches, so the script doesn't halt
+# If there's an error "Argument list too long" add -n20 to xargs arguments and loop over $FILE around sed
+FILES=`find . -type d \( -name ignored -or -name .?\* \) -prune \
+       -o -type f -not \( -name \*.log -or -name '*.war' -or -name '*.min.js' -or -name '*.min.css' \) -print0 | \
+       xargs -0 grep -l "${VERSION_MARKER}\|${VERSION_MARKER_NL}" /dev/null || true`
+
+FILES_COUNT=`echo $FILES | wc | awk '{print $2}'`
+
+if [ ${FILES_COUNT} -ne 0 ]; then
+    # search for files containing version markers
+    sed -i.bak -e "/${VERSION_MARKER}/s/${CURRENT_VERSION}/${NEW_VERSION}/g" $FILES
+    sed -i.bak -e "/${VERSION_MARKER_NL}/{n;s/${CURRENT_VERSION}/${NEW_VERSION}/g;}" $FILES
+fi
+
+echo "Changed ${CURRENT_VERSION} to ${NEW_VERSION} for "${FILES_COUNT}" files"
+echo "(Do a \`find . -name \"*.bak\" -delete\`  to delete the backup files.)"

--- a/scripts/release-make.sh
+++ b/scripts/release-make.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# 
+# Not using maven release plugin as:
+#  * not all projects are tagged
+#  * incubator-brooklyn is using a different scm for the tags
+#  * version is changed in more than the pom.xml files
+
+# CUSTOMIZE:
+
+: ${RELEASE_DATE:=${1:-$(date +"%Y%m%d.%H%M")}}
+
+: ${MAVEN_REPO_ID:=cloudsoft-artifactory-repo}
+: ${MAVEN_REPO_URL:=http://ccweb.cloudsoftcorp.com/maven/libs-release-local/}
+
+# Note advanced networking does not have a separate version identifier in code, but it should!
+
+# BROOKLYN_VERSION_BELOW
+: ${BROOKLYN_GA_VERSION:=0.7.0}
+# ADVANCED_NETWORKING_VERSION_BELOW
+: ${ADVANCED_NETWORKING_GA_VERSION:=0.7.0}
+: ${BROOKLYN_STABLE_VERSION:=0.7.0-20150614.2158}
+
+
+# /CUSTOMIZE
+
+
+#stop script on error
+set -e
+
+if [ ! -d .git ]; then
+  echo "Must be run from the advanced-networking root folder"
+  exit 1
+fi
+
+echo Deploying to ${MAVEN_REPO_URL} tagged ${RELEASE_DATE}.
+echo Building from:
+echo incubator-brooklyn: $BROOKLYN_STABLE_VERSION
+echo advanced-networking: $(git symbolic-ref HEAD 2> /dev/null || git rev-parse HEAD) @ $(git config --get remote.origin.url)
+echo
+
+# Needed for Java 6
+export MAVEN_OPTS="-Xmx1024m -XX:MaxPermSize=256m"
+
+ADVANCED_NETWORKING_PATH=`pwd`
+RELEASES_PATH=${ADVANCED_NETWORKING_PATH}/ignored/releases
+MAVEN_REPO_PATH=${ADVANCED_NETWORKING_PATH}/ignored/maven-repo
+CV=${ADVANCED_NETWORKING_PATH}/scripts/change-version.sh
+REVISIONS=${ADVANCED_NETWORKING_PATH}/vcloud-director-nat-microservice/src/main/assembly/conf/revisions.txt
+
+function check_no_snapshot_deps {
+    local SNAPSHOTS=`mvn --batch-mode dependency:list -DexcludeTransitive=true | \
+               grep '\[INFO\]    .*SNAPSHOT' | \
+               sed -e 's/^.\{6\}//' | \
+               sort | \
+               uniq`
+               
+    if [ ! -z "$SNAPSHOTS" ]; then
+    	echo
+        echo FATAL: $REPO_NAME has SNAPSHOT dependencies, aborting:
+        echo "$SNAPSHOTS"
+        exit 1
+    fi
+}
+
+function change_version {
+    local REPO_NAME=`basename $(pwd)`
+
+    echo
+    echo Changing version of ${REPO_NAME} at `date`
+    echo =================================================================
+
+    ${CV} ${BROOKLYN_GA_VERSION}-SNAPSHOT $BROOKLYN_STABLE_VERSION
+    ${CV} ADVANCED_NETWORKING ${ADVANCED_NETWORKING_GA_VERSION}-SNAPSHOT ${ADVANCED_NETWORKING_GA_VERSION}-${RELEASE_DATE}
+
+    find . -name "*.bak" -delete
+}
+
+function build_and_deploy {
+    local REPO_PATH=$1
+    local BUILD_ARGS=$2
+
+    pushd ${REPO_PATH} > /dev/null
+
+    local REPO_REV=`git rev-parse --verify HEAD`
+    local REPO_NAME=`basename $(pwd)`
+    local REPO_BRANCH=`git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\1/'`
+    echo ${REPO_NAME}: ${REPO_BRANCH}: ${REPO_REV} >> ${REVISIONS}
+    
+    echo
+    echo Building ${REPO_NAME} at `date`
+    echo =================================================================
+    
+    change_version
+    check_no_snapshot_deps
+
+    mvn --batch-mode clean deploy -Dmaven.repo.local=${MAVEN_REPO_PATH} -Dgpg.skip=true \
+    	-DaltDeploymentRepository=${MAVEN_REPO_ID}::default::${MAVEN_REPO_URL} \
+        -DskipTests \
+    	${BUILD_ARGS}
+
+    popd > /dev/null
+}
+
+mkdir -p ignored
+mkdir -p ${MAVEN_REPO_PATH}
+rm -f ${REVISIONS}
+
+build_and_deploy ./
+echo incubator-brookyn: $BROOKLYN_STABLE_VERSION >> ${REVISIONS}
+REVISIONS_SUMMARY=`cat ${REVISIONS}`
+
+echo
+echo Tag projects at `date`
+echo =================================================================
+echo "${REVISIONS_SUMMARY}"
+
+## advanced-networking
+git remote -v | grep releases || \
+    git remote add releases git@github.com:cloudsoft/advanced-networking-cloudsoft-releases.git
+git add --all
+git commit -m "Release version ${ADVANCED_NETWORKING_GA_VERSION}-${RELEASE_DATE}
+
+${REVISIONS_SUMMARY}"
+
+git tag nightly-${RELEASE_DATE}
+git push releases nightly-${RELEASE_DATE}
+
+echo Successfully created release ${RELEASE_DATE}

--- a/vcloud-director-nat-microservice/pom.xml
+++ b/vcloud-director-nat-microservice/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vcloud-director-nat-microservice/src/main/assembly/conf/revisions.txt
+++ b/vcloud-director-nat-microservice/src/main/assembly/conf/revisions.txt
@@ -1,0 +1,1 @@
+advanced-networking: master: 5cf7f95f131c9a489357e08b49af8f806d9c4019

--- a/vcloud-director-portforwarding/pom.xml
+++ b/vcloud-director-portforwarding/pom.xml
@@ -143,6 +143,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>airline</artifactId>
+            <version>0.6</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/vcloud-director-portforwarding/pom.xml
+++ b/vcloud-director-portforwarding/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.7.0-SNAPSHOT</version> <!-- BROOKLYN_VERSION -->
+        <version>0.7.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Pulls in changes from https://github.com/brooklyncentral/advanced-networking/pull/65, but using `0.7.0-SNAPSHOT`.