### PR TITLE
Removes airline dependency from vcloud-director-portforwarding

### DIFF
--- a/vcloud-director-portforwarding/pom.xml
+++ b/vcloud-director-portforwarding/pom.xml
@@ -143,11 +143,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>airline</artifactId>
-            <version>0.6</version>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
The project vcloud-director-nat-microservice already has a dependency 
on io.airlift:airline.

@nakomis can you review please?
