### PR TITLE
UriTransformingEnricher: handle ip:port as well as URI

### DIFF
--- a/cloudstack/src/main/java/brooklyn/networking/cloudstack/legacy/LegacyJcloudsCloudstackSubnetLocation.java
+++ b/cloudstack/src/main/java/brooklyn/networking/cloudstack/legacy/LegacyJcloudsCloudstackSubnetLocation.java
@@ -29,38 +29,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.annotation.Nullable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.net.HostAndPort;
-
-import org.jclouds.cloudstack.CloudStackApi;
-import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
-import org.jclouds.cloudstack.domain.AsyncCreateResponse;
-import org.jclouds.cloudstack.domain.FirewallRule;
-import org.jclouds.cloudstack.domain.NIC;
-import org.jclouds.cloudstack.domain.PortForwardingRule;
-import org.jclouds.cloudstack.domain.VirtualMachine;
-import org.jclouds.cloudstack.features.VirtualMachineApi;
-import org.jclouds.cloudstack.options.CreateFirewallRuleOptions;
-import org.jclouds.compute.ComputeService;
-import org.jclouds.compute.domain.NodeMetadata;
-import org.jclouds.compute.domain.OperatingSystem;
-import org.jclouds.compute.domain.OsFamily;
-
 import org.apache.brooklyn.api.location.NoMachinesAvailableException;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.config.Sanitizer;
 import org.apache.brooklyn.core.location.access.BrooklynAccessUtils;
 import org.apache.brooklyn.core.location.access.PortForwardManager;
 import org.apache.brooklyn.location.jclouds.AbstractJcloudsSubnetSshMachineLocation;
@@ -82,6 +55,31 @@ import org.apache.brooklyn.util.ssh.BashCommands;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
+import org.jclouds.cloudstack.CloudStackApi;
+import org.jclouds.cloudstack.compute.options.CloudStackTemplateOptions;
+import org.jclouds.cloudstack.domain.AsyncCreateResponse;
+import org.jclouds.cloudstack.domain.FirewallRule;
+import org.jclouds.cloudstack.domain.NIC;
+import org.jclouds.cloudstack.domain.PortForwardingRule;
+import org.jclouds.cloudstack.domain.VirtualMachine;
+import org.jclouds.cloudstack.features.VirtualMachineApi;
+import org.jclouds.cloudstack.options.CreateFirewallRuleOptions;
+import org.jclouds.compute.ComputeService;
+import org.jclouds.compute.domain.NodeMetadata;
+import org.jclouds.compute.domain.OperatingSystem;
+import org.jclouds.compute.domain.OsFamily;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.net.HostAndPort;
 
 import brooklyn.networking.NetworkMultiAddressUtils2;
 import brooklyn.networking.cloudstack.CloudstackNew40FeaturesClient;
@@ -300,7 +298,7 @@ public class LegacyJcloudsCloudstackSubnetLocation extends JcloudsLocation {
                     getUser(setup),
                     vmHostname,
                     setup.getDescription(),
-                    Entities.sanitize(sshConfig)
+                    Sanitizer.sanitize(sshConfig)
             });
         }
 
@@ -325,8 +323,8 @@ public class LegacyJcloudsCloudstackSubnetLocation extends JcloudsLocation {
         l.init();
         getManagementContext().getLocationManager().manage(l);
 
-        l.setConfig(SUBNET_HOSTNAME_CONFIG, subnetSpecificHostname);
-        l.setConfig(VM_IDENTIFIER, node.getId());
+        l.config().set(SUBNET_HOSTNAME_CONFIG, subnetSpecificHostname);
+        l.config().set(VM_IDENTIFIER, node.getId());
 
         if (portForwardingMode) {
             // record port 22 forwarding

--- a/cloudstack/src/main/java/brooklyn/networking/cloudstack/legacy/VirtualPrivateCloud.java
+++ b/cloudstack/src/main/java/brooklyn/networking/cloudstack/legacy/VirtualPrivateCloud.java
@@ -76,7 +76,7 @@ public class VirtualPrivateCloud {
                         log.info("Created VPC "+vpcId+" on start of "+owner);
                     }
                     Tasks.setBlockingDetails(null);
-                    ((AbstractEntity)owner).setAttribute(VPC_ID, vpcId);
+                    owner.sensors().set(VPC_ID, vpcId);
                     return jl.newSubLocation(MutableMap.of(
                             LegacyJcloudsCloudstackSubnetLocation.CLOUDSTACK_VPC_ID, vpcId,
                             LegacyJcloudsCloudstackSubnetLocation.CLOUDSTACK_ZONE_ID, zoneId
@@ -97,7 +97,7 @@ public class VirtualPrivateCloud {
 
                     log.info("Deleting VPC on stop of "+owner);
                     cloudstackClient.deleteVpc(owner.getAttribute(VPC_ID));
-                    ((AbstractEntity)owner).setAttribute(VPC_ID, null);
+                    owner.sensors().set(VPC_ID, null);
                 }
             }
         }

--- a/cloudstack/src/main/java/brooklyn/networking/cloudstack/loadbalancer/CloudStackLoadBalancerImpl.java
+++ b/cloudstack/src/main/java/brooklyn/networking/cloudstack/loadbalancer/CloudStackLoadBalancerImpl.java
@@ -102,8 +102,8 @@ public class CloudStackLoadBalancerImpl extends AbstractNonProvisionedController
         ConfigToAttributes.apply(this);
 
         addLocations(locations);
-        setAttribute(SERVICE_UP, false);
-        setAttribute(SERVICE_STATE, Lifecycle.STARTING);
+        sensors().set(SERVICE_UP, false);
+        sensors().set(SERVICE_STATE, Lifecycle.STARTING);
         try {
             super.start(locations);
 
@@ -117,11 +117,11 @@ public class CloudStackLoadBalancerImpl extends AbstractNonProvisionedController
             loadBalancerApi = client.getLoadBalancerClient();
 
             startLoadBalancer();
-            setAttribute(SERVICE_UP, true);
-            setAttribute(SERVICE_STATE, Lifecycle.RUNNING);
+            sensors().set(SERVICE_UP, true);
+            sensors().set(SERVICE_STATE, Lifecycle.RUNNING);
             isActive = true;
         } catch (Exception e) {
-            setAttribute(SERVICE_STATE, Lifecycle.ON_FIRE);
+            sensors().set(SERVICE_STATE, Lifecycle.ON_FIRE);
             throw Exceptions.propagate(e);
         }
     }
@@ -130,9 +130,9 @@ public class CloudStackLoadBalancerImpl extends AbstractNonProvisionedController
     public void stop() {
         // TODO Should we delete the load balancer?
         loc = null;
-        setAttribute(SERVICE_STATE, Lifecycle.STOPPING);
-        setAttribute(SERVICE_UP, false);
-        setAttribute(SERVICE_STATE, Lifecycle.STOPPED);
+        sensors().set(SERVICE_STATE, Lifecycle.STOPPING);
+        sensors().set(SERVICE_UP, false);
+        sensors().set(SERVICE_STATE, Lifecycle.STOPPED);
     }
 
     @Override
@@ -197,7 +197,7 @@ public class CloudStackLoadBalancerImpl extends AbstractNonProvisionedController
         if (Strings.isBlank(lbName)) {
             ConfigBag setup = ConfigBag.newInstance(getAllConfig());
             lbName = new BasicCloudMachineNamer().generateNewGroupId(setup);
-            setAttribute(LOAD_BALANCER_NAME, lbName);
+            sensors().set(LOAD_BALANCER_NAME, lbName);
         }
         createLoadBalancer(lbName);
     }
@@ -236,11 +236,11 @@ public class CloudStackLoadBalancerImpl extends AbstractNonProvisionedController
         LoadBalancerRule rule = (LoadBalancerRule) job.getResult();
         String loadBalancerId = rule.getId();
 
-        setAttribute(LOAD_BALANCER_ID, loadBalancerId);
-        setAttribute(PROXY_HTTP_PORT, loadBalancerPort);
-        setAttribute(HOSTNAME, ip.getIPAddress());
-        setAttribute(PROTOCOL, inferProtocol());
-        setAttribute(ROOT_URL, inferUrl());
+        sensors().set(LOAD_BALANCER_ID, loadBalancerId);
+        sensors().set(PROXY_HTTP_PORT, loadBalancerPort);
+        sensors().set(HOSTNAME, ip.getIPAddress());
+        sensors().set(PROTOCOL, inferProtocol());
+        sensors().set(ROOT_URL, inferUrl());
     }
 
     @Override

--- a/common/src/test/java/brooklyn/networking/AttributeMungerTest.java
+++ b/common/src/test/java/brooklyn/networking/AttributeMungerTest.java
@@ -57,7 +57,7 @@ public class AttributeMungerTest {
         loc = app.getManagementContext().getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
         app.start(ImmutableList.of(loc));
 
-        app.subscribe(app, TestApplication.MY_ATTRIBUTE, new SensorEventListener<String>() {
+        app.subscriptions().subscribe(app, TestApplication.MY_ATTRIBUTE, new SensorEventListener<String>() {
                 @Override public void onEvent(SensorEvent<String> event) {
                     events.add(event.getValue());
                 }});
@@ -99,10 +99,10 @@ public class AttributeMungerTest {
                 ImmutableList.of(TARGET_HOSTNAME, OTHER_HOSTNAME),
                 new EntityAndAttribute<String>(app, PUBLIC_ENDPOINT));
 
-        app.setAttribute(TARGET_HOSTNAME, "myprivatehostname");
-        app.setAttribute(TARGET_PORT, 1234);
-        app.setAttribute(ENDPOINT, "PREFIX://myprivatehostname:1234/POSTFIX");
-        app.setAttribute(PUBLIC_ENDPOINT, "mypublichostname:5678");
+        app.sensors().set(TARGET_HOSTNAME, "myprivatehostname");
+        app.sensors().set(TARGET_PORT, 1234);
+        app.sensors().set(ENDPOINT, "PREFIX://myprivatehostname:1234/POSTFIX");
+        app.sensors().set(PUBLIC_ENDPOINT, "mypublichostname:5678");
 
         EntityTestUtils.assertAttributeEqualsEventually(app, ENDPOINT, "PREFIX://mypublichostname:5678/POSTFIX");
     }

--- a/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTierImpl.java
+++ b/portforwarding/src/main/java/brooklyn/networking/subnet/SubnetTierImpl.java
@@ -120,9 +120,9 @@ public class SubnetTierImpl extends AbstractEntity implements SubnetTier {
             pfmLive = pfmFromConf;
         }
         
-        setConfig(PORT_FORWARDING_MANAGER, pfmLive);
-        setAttribute(PORT_FORWARD_MANAGER_LIVE, pfmLive);
-        setAttribute(PORT_FORWARDER_LIVE, pf);
+        config().set(PORT_FORWARDING_MANAGER, pfmLive);
+        sensors().set(PORT_FORWARD_MANAGER_LIVE, pfmLive);
+        sensors().set(PORT_FORWARDER_LIVE, pf);
         if (log.isDebugEnabled()) log.debug("Subnet tier {} using PortForwardManager {}, and port forwarder {}", new Object[] {this, pfmLive, pf});
 
         // TODO For rebind, would require to re-register this; same for portMappedEntities field
@@ -143,7 +143,7 @@ public class SubnetTierImpl extends AbstractEntity implements SubnetTier {
         super.initEnrichers();
         
         // default app logic; easily overridable by adding a different enricher with the same tag
-        addEnricher(ServiceStateLogic.newEnricherFromChildren().checkChildrenOnly());
+        enrichers().add(ServiceStateLogic.newEnricherFromChildren().checkChildrenOnly());
         ServiceStateLogic.ServiceNotUpLogic.updateNotUpIndicator(this, Attributes.SERVICE_STATE_ACTUAL, "Subnet created but not yet started, at "+Time.makeDateString());
     }
 
@@ -348,7 +348,7 @@ public class SubnetTierImpl extends AbstractEntity implements SubnetTier {
         }
         if (result != null) {
             result.injectManagementContext(getManagementContext());
-            setAttribute(PORT_FORWARDER_LIVE, result);
+            sensors().set(PORT_FORWARDER_LIVE, result);
         }
         return result;
     }
@@ -411,21 +411,21 @@ public class SubnetTierImpl extends AbstractEntity implements SubnetTier {
     public void transformPort(EntityAndAttribute<Integer> original, EntityAndAttribute<String> destinationToPublish) {
         // TODO Should we do this without an enricher? Or change #transformSensorStringReplacingWithPublicAddressAndPort 
         // to not use an enricher?
-        destinationToPublish.getEntity().addEnricher(hostAndPortTransformingEnricher(original, destinationToPublish.getAttribute()));
+        destinationToPublish.getEntity().enrichers().add(hostAndPortTransformingEnricher(original, destinationToPublish.getAttribute()));
     }
     
     public void transformUri(EntityAndAttribute<String> targetToUpdate) {
         // TODO Should we change #transformSensorStringReplacingWithPublicAddressAndPort 
         // to not use an enricher?
         Entity entity = targetToUpdate.getEntity();
-        entity.addEnricher(uriTransformingEnricher(targetToUpdate, targetToUpdate.getAttribute())
+        entity.enrichers().add(uriTransformingEnricher(targetToUpdate, targetToUpdate.getAttribute())
                 .configure(Transformer.SUPPRESS_DUPLICATES, true));
     }
     
     public void transformUri(EntityAndAttribute<String> original, EntityAndAttribute<String> destinationToPublish) {
         // TODO Should we do this without an enricher? Or change #transformSensorStringReplacingWithPublicAddressAndPort 
         // to not use an enricher?
-        destinationToPublish.getEntity().addEnricher(uriTransformingEnricher(original, destinationToPublish.getAttribute()));
+        destinationToPublish.getEntity().enrichers().add(uriTransformingEnricher(original, destinationToPublish.getAttribute()));
     }
     
     @Override

--- a/portforwarding/src/test/java/brooklyn/example/ExampleForwardingEntityImpl.java
+++ b/portforwarding/src/test/java/brooklyn/example/ExampleForwardingEntityImpl.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Iterables;
 
 import org.apache.brooklyn.api.entity.Entity;
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
@@ -53,13 +52,13 @@ public class ExampleForwardingEntityImpl extends VanillaJavaAppImpl implements E
 
             Integer originPort = originEntity.getAttribute(originPortAttribute);
             SshMachineLocation fakeDb = (SshMachineLocation) getMachineOrNull();
-            SshMachineLocation realDb = (SshMachineLocation) Iterables.getFirst( ((EntityLocal)originEntity).getLocations(), null );
+            SshMachineLocation realDb = (SshMachineLocation) Iterables.getFirst(originEntity.getLocations(), null);
             String originPublicKeyData = originEntity.getAttribute(PUBLIC_KEY_DATA);
 
             if (originPublicKeyData==null) {
                 synchronized (realDb) {
                     originPublicKeyData = SshTunnelling.generateRsaKey(realDb);
-                    ((EntityLocal)originEntity).setAttribute(PUBLIC_KEY_DATA, originPublicKeyData );
+                    originEntity.sensors().set(PUBLIC_KEY_DATA, originPublicKeyData );
                 }
             }
 

--- a/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
@@ -191,6 +191,24 @@ public class SubnetTierTest {
         EntityTestUtils.assertAttributeEqualsEventually(entity, PUBLIC_ENDPOINT, "http://"+publicAddress+":"+40080);
     }
 
+    @Test
+    public void testUriTransformingEnricherWithSourceSetToHostAndPort() throws Exception {
+        final AttributeSensor<String> ENDPOINT = new BasicAttributeSensor<String>(String.class, "endpoint");
+        final AttributeSensor<String> PUBLIC_ENDPOINT = new BasicAttributeSensor<String>(String.class, "publicEndpoint");
+
+        String publicIpId = "mypublicipid";
+        String publicAddress = "5.6.7.8";
+        portMapping.put(HostAndPort.fromParts(machineAddress, 80), HostAndPort.fromParts(publicAddress, 40080));
+        portForwardManager.associate(publicIpId, HostAndPort.fromParts(publicAddress, 40080), simulatedMachine, 80);
+
+        entity.addEnricher(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
+
+        entity.addLocations(ImmutableList.of(simulatedMachine));
+        entity.setAttribute(ENDPOINT, machineAddress+":80");
+
+        EntityTestUtils.assertAttributeEqualsEventually(entity, PUBLIC_ENDPOINT, publicAddress+":"+40080);
+    }
+
     /**
      * Tests that the transformed URI is published, even if the port-mapping is only set after the 
      * transforming enricher has processed the original attribute-changed event.

--- a/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/subnet/SubnetTierTest.java
@@ -116,10 +116,10 @@ public class SubnetTierTest {
                 Optional.of(new EntityAndAttribute<Integer>(app, TARGET_PORT)),
                 new EntityAndAttribute<String>(app, PUBLIC_ENDPOINT));
 
-        ((EntityLocal)app).setAttribute(Attributes.HOSTNAME, "myprivatehostname");
-        ((EntityLocal)app).setAttribute(TARGET_PORT, 1234);
-        ((EntityLocal)app).setAttribute(ENDPOINT, "PREFIX://myprivatehostname:1234/POSTFIX");
-        ((EntityLocal)app).setAttribute(PUBLIC_ENDPOINT, "mypublichostname:5678");
+        app.sensors().set(Attributes.HOSTNAME, "myprivatehostname");
+        app.sensors().set(TARGET_PORT, 1234);
+        app.sensors().set(ENDPOINT, "PREFIX://myprivatehostname:1234/POSTFIX");
+        app.sensors().set(PUBLIC_ENDPOINT, "mypublichostname:5678");
 
         log.info(app.getAttribute(ENDPOINT));
 
@@ -136,12 +136,12 @@ public class SubnetTierTest {
         portMapping.put(HostAndPort.fromParts(machineAddress, 80), HostAndPort.fromParts(publicAddress, 40080));
         portForwardManager.associate(publicIpId, HostAndPort.fromParts(publicAddress, 40080), simulatedMachine, 80);
 
-        entity.addEnricher(subnetTier.hostAndPortTransformingEnricher(
+        entity.enrichers().add(subnetTier.hostAndPortTransformingEnricher(
                 new EntityAndAttribute<Integer>(entity, TARGET_PORT),
                 PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(TARGET_PORT, 80);
+        entity.sensors().set(TARGET_PORT, 80);
 
         EntityTestUtils.assertAttributeEqualsEventually(entity, PUBLIC_ENDPOINT, publicAddress+":"+40080);
     }
@@ -154,14 +154,14 @@ public class SubnetTierTest {
         String publicIpId = "mypublicipid";
         String publicAddress = "5.6.7.8";
         RecordingSensorEventListener sensorListener = new RecordingSensorEventListener();
-        entity.subscribe(entity, PUBLIC_ENDPOINT, sensorListener);
+        entity.subscriptions().subscribe(entity, PUBLIC_ENDPOINT, sensorListener);
 
-        entity.addEnricher(subnetTier.hostAndPortTransformingEnricher(
+        entity.enrichers().add(subnetTier.hostAndPortTransformingEnricher(
                 new EntityAndAttribute<Integer>(entity, TARGET_PORT),
                 PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(TARGET_PORT, 80);
+        entity.sensors().set(TARGET_PORT, 80);
 
         // TODO It sets the sensor to null (!). We'll rely on that for now, but feels like it 
         // shouldn't bother setting it at all!
@@ -183,10 +183,10 @@ public class SubnetTierTest {
         portMapping.put(HostAndPort.fromParts(machineAddress, 80), HostAndPort.fromParts(publicAddress, 40080));
         portForwardManager.associate(publicIpId, HostAndPort.fromParts(publicAddress, 40080), simulatedMachine, 80);
 
-        entity.addEnricher(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
+        entity.enrichers().add(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, "http://"+machineAddress+":80");
+        entity.sensors().set(ENDPOINT, "http://"+machineAddress+":80");
 
         EntityTestUtils.assertAttributeEqualsEventually(entity, PUBLIC_ENDPOINT, "http://"+publicAddress+":"+40080);
     }
@@ -201,10 +201,10 @@ public class SubnetTierTest {
         portMapping.put(HostAndPort.fromParts(machineAddress, 80), HostAndPort.fromParts(publicAddress, 40080));
         portForwardManager.associate(publicIpId, HostAndPort.fromParts(publicAddress, 40080), simulatedMachine, 80);
 
-        entity.addEnricher(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
+        entity.enrichers().add(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, machineAddress+":80");
+        entity.sensors().set(ENDPOINT, machineAddress+":80");
 
         EntityTestUtils.assertAttributeEqualsEventually(entity, PUBLIC_ENDPOINT, publicAddress+":"+40080);
     }
@@ -224,12 +224,12 @@ public class SubnetTierTest {
         String publicIpId = "mypublicipid";
         String publicAddress = "5.6.7.8";
         RecordingSensorEventListener sensorListener = new RecordingSensorEventListener();
-        entity.subscribe(entity, PUBLIC_ENDPOINT, sensorListener);
+        entity.subscriptions().subscribe(entity, PUBLIC_ENDPOINT, sensorListener);
 
-        entity.addEnricher(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
+        entity.enrichers().add(subnetTier.uriTransformingEnricher(ENDPOINT, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, "http://" + machineAddress + ":80");
+        entity.sensors().set(ENDPOINT, "http://" + machineAddress + ":80");
 
         // TODO It sets the sensor to the original (unmapped) value. However, that is different
         // behaviour from transformPort or transformHostAndPortEnricher which both just set the
@@ -254,7 +254,7 @@ public class SubnetTierTest {
         subnetTier.transformUri(new EntityAndAttribute<String>(entity, ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, "http://"+machineAddress+":80");
+        entity.sensors().set(ENDPOINT, "http://"+machineAddress+":80");
 
         EntityTestUtils.assertAttributeEqualsEventually(entity, ENDPOINT, "http://"+publicAddress+":"+40080);
     }
@@ -272,7 +272,7 @@ public class SubnetTierTest {
         subnetTier.transformUri(new EntityAndAttribute<String>(entity, ENDPOINT), new EntityAndAttribute<String>(app, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, "http://"+machineAddress+":80");
+        entity.sensors().set(ENDPOINT, "http://"+machineAddress+":80");
 
         EntityTestUtils.assertAttributeEqualsEventually(app, PUBLIC_ENDPOINT, "http://"+publicAddress+":"+40080);
     }
@@ -285,12 +285,12 @@ public class SubnetTierTest {
         String publicIpId = "mypublicipid";
         String publicAddress = "5.6.7.8";
         RecordingSensorEventListener sensorListener = new RecordingSensorEventListener();
-        entity.subscribe(app, PUBLIC_ENDPOINT, sensorListener);
+        entity.subscriptions().subscribe(app, PUBLIC_ENDPOINT, sensorListener);
 
         subnetTier.transformUri(new EntityAndAttribute<String>(entity, ENDPOINT), new EntityAndAttribute<String>(app, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, "http://"+machineAddress+":80");
+        entity.sensors().set(ENDPOINT, "http://"+machineAddress+":80");
 
         sensorListener.assertEventEventually(Duration.THIRTY_SECONDS);
 
@@ -313,7 +313,7 @@ public class SubnetTierTest {
         subnetTier.transformPort(EntityAndAttribute.create(entity, ENDPOINT), EntityAndAttribute.create(app, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, 80);
+        entity.sensors().set(ENDPOINT, 80);
 
         EntityTestUtils.assertAttributeEqualsEventually(app, PUBLIC_ENDPOINT, publicAddress+":"+40080);
     }
@@ -326,12 +326,12 @@ public class SubnetTierTest {
         String publicIpId = "mypublicipid";
         String publicAddress = "5.6.7.8";
         RecordingSensorEventListener sensorListener = new RecordingSensorEventListener();
-        entity.subscribe(app, PUBLIC_ENDPOINT, sensorListener);
+        entity.subscriptions().subscribe(app, PUBLIC_ENDPOINT, sensorListener);
 
         subnetTier.transformPort(EntityAndAttribute.create(entity, ENDPOINT), EntityAndAttribute.create(app, PUBLIC_ENDPOINT));
 
         entity.addLocations(ImmutableList.of(simulatedMachine));
-        entity.setAttribute(ENDPOINT, 80);
+        entity.sensors().set(ENDPOINT, 80);
         
         // TODO It sets the sensor to null (!). We'll rely on that for now, but feels like it 
         // shouldn't bother setting it at all!

--- a/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
+++ b/vcloud-director-nat-microservice/src/test/java/brooklyn/networking/vclouddirector/natmicroservice/NatServiceMicroserviceAbstractLiveTest.java
@@ -72,7 +72,7 @@ public abstract class NatServiceMicroserviceAbstractLiveTest extends AbstractRes
         vDC = loc.getRegion();
         identity = loc.getIdentity();
         credential = loc.getCredential();
-        publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+        publicIp = (String) checkNotNull(loc.config().getBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
 
         super.setUp();
     }

--- a/vcloud-director-portforwarding/src/test/java/brooklyn/networking/vclouddirector/NatMicroserviceClientLiveTest.java
+++ b/vcloud-director-portforwarding/src/test/java/brooklyn/networking/vclouddirector/NatMicroserviceClientLiveTest.java
@@ -77,7 +77,7 @@ public class NatMicroserviceClientLiveTest extends BrooklynAppLiveTestSupport {
         
         super.setUp();
         loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
-        publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+        publicIp = (String) checkNotNull(loc.config().getBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
         
         // Create the NAT Micro-service
         String endpointsProperties = "my-vcloud.endpoint="+NatDirectClient.transformEndpoint(loc.getEndpoint()) + "\n"

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/AbstractNatServiceLiveTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractNatServiceLiveTest extends BrooklynAppLiveTestSupp
     public void setUp() throws Exception {
         super.setUp();
         loc = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_SPEC);
-        publicIp = (String) checkNotNull(loc.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+        publicIp = (String) checkNotNull(loc.config().getBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
         
         executor = MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
     }

--- a/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
+++ b/vcloud-director/src/test/java/brooklyn/networking/vclouddirector/NatServiceLiveTest.java
@@ -83,7 +83,7 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
     @Test(groups="Live")
     public void testAddNatRuleAtTai2() throws Exception {
         JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_2_SPEC);
-        String publicIp2 = (String) checkNotNull(loc2.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+        String publicIp2 = (String) checkNotNull(loc2.config().getBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
 
         HostAndPort targetEndpoint = HostAndPort.fromParts(INTERNAL_MACHINE_IP_TAI_2, 1);
         HostAndPort publicEndpoint = HostAndPort.fromString(publicIp2);
@@ -112,7 +112,7 @@ public class NatServiceLiveTest extends AbstractNatServiceLiveTest {
     @Test(groups="Live")
     public void testAddNatRuleAtTai2b() throws Exception {
         JcloudsLocation loc2 = (JcloudsLocation) mgmt.getLocationRegistry().resolve(LOCATION_TAI_2b_SPEC);
-        String publicIp2 = (String) checkNotNull(loc2.getAllConfigBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
+        String publicIp2 = (String) checkNotNull(loc2.config().getBag().getStringKey("advancednetworking.vcloud.network.publicip"), "publicip");
 
         HostAndPort targetEndpoint = HostAndPort.fromParts(INTERNAL_MACHINE_IP_TAI_2b, 1);
         HostAndPort publicEndpoint = HostAndPort.fromString(publicIp2);


### PR DESCRIPTION
Pasting code comment here for your convinience when reviewing:

    /**
     * Transforms a URI (or a HostAndPort) string to the mapped value. Or if there is no
     * port-forward rule defined for the given port on this entity's machine, then just 
     * return the source value.
     * 
     * We now handle both URI and HostAndPort to assist backwards compatibility. For example,
     * MongoDBServer.MONGO_SERVER_ENDPOINT changed from being a URI to being a ip:port, but
     * customers are using the {@link SubnetTier#transformUri(EntityAndAttribute)} to map
     * that sensor. When it changed from being a URI, the customer blueprints broke.
     */

The second commit is just updating use of things like `setAttribute()` to `sensors().set()`.