### PR TITLE
Bump to 0.8.1-SNAPSHOT and depend on Brooklyn 0.8.0-incubating

### DIFF
--- a/cloudstack/pom.xml
+++ b/cloudstack/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
+        <version>0.8.1-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
+        <version>0.8.1-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>io.brooklyn.networking</groupId>
     <artifactId>brooklyn-networking-parent</artifactId>
     <packaging>pom</packaging>
-    <version>0.8.0-SNAPSHOT</version>  <!-- ADVANCED_NETWORKING_VERSION -->
+    <version>0.8.1-SNAPSHOT</version>  <!-- ADVANCED_NETWORKING_VERSION -->
 
     <name>Brooklyn Advanced Networking</name>
     <description>
@@ -32,12 +32,12 @@
     <parent>
         <groupId>org.apache.brooklyn</groupId>
         <artifactId>brooklyn-downstream-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <version>0.8.0-incubating</version>  <!-- BROOKLYN_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>
-        <brooklyn.version>0.8.0-SNAPSHOT</brooklyn.version> <!-- BROOKLYN_VERSION -->
+        <brooklyn.version>0.8.0-incubating</brooklyn.version> <!-- BROOKLYN_VERSION -->
         <jclouds.groupId>org.apache.jclouds</jclouds.groupId>
     </properties>
 

--- a/portforwarding/pom.xml
+++ b/portforwarding/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
+        <version>0.8.1-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vcloud-director-nat-microservice/pom.xml
+++ b/vcloud-director-nat-microservice/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
+        <version>0.8.1-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vcloud-director-portforwarding/pom.xml
+++ b/vcloud-director-portforwarding/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
+        <version>0.8.1-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/vcloud-director/pom.xml
+++ b/vcloud-director/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.brooklyn.networking</groupId>
         <artifactId>brooklyn-networking-parent</artifactId>
-        <version>0.8.0-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
+        <version>0.8.1-SNAPSHOT</version> <!-- ADVANCED_NETWORKING_VERSION -->
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Was previously 0.8.0-SNAPSHOT, depending on brooklyn 0.8.0-SNAPSHOT