### PR TITLE
Added no arg constructor

### DIFF
--- a/cloudstack/src/main/java/brooklyn/networking/cloudstack/portforwarding/CloudstackPortForwarder.java
+++ b/cloudstack/src/main/java/brooklyn/networking/cloudstack/portforwarding/CloudstackPortForwarder.java
@@ -73,6 +73,10 @@ public class CloudstackPortForwarder implements PortForwarder {
     private SubnetTier subnetTier;
     private JcloudsLocation jcloudsLocation;
 
+    public CloudstackPortForwarder() {
+
+    }
+
     public CloudstackPortForwarder(PortForwardManager portForwardManager) {
         this.portForwardManager = portForwardManager;
     }


### PR DESCRIPTION
Added a no arg constructor to CloudstackPortForwarder so that it can be used by YAML entities