### PR TITLE
Remove jclouds.groupId as it will be obtained from Brooklyn.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <properties>
         <brooklyn.version>0.10.0-SNAPSHOT</brooklyn.version> <!-- BROOKLYN_VERSION -->
         <vcloud-director.version>1.9.2</vcloud-director.version>
-        <jclouds.groupId>org.apache.jclouds</jclouds.groupId> <!-- JCLOUDS_GROUPID_VERSION -->
         <vcloud.director.api.version>5.5.0</vcloud.director.api.version>
         <guava.version>16.0.1</guava.version>
         <rabbitmq.amqp-clinet.version>2.8.7</rabbitmq.amqp-clinet.version>


### PR DESCRIPTION
The value for jclouds.groupId will be defined by Brooklyn
via the brooklyn-downstream-parent pom.