### PR TITLE
Updates unit tests due to ApplicationBuilder removal

### DIFF
--- a/common/src/test/java/brooklyn/networking/AttributeMungerTest.java
+++ b/common/src/test/java/brooklyn/networking/AttributeMungerTest.java
@@ -20,6 +20,7 @@ import static org.testng.Assert.assertEquals;
 import java.util.List;
 
 import org.apache.brooklyn.core.entity.EntityAsserts;
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -38,22 +39,20 @@ import org.apache.brooklyn.api.sensor.SensorEvent;
 import org.apache.brooklyn.api.sensor.SensorEventListener;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.entity.EntityAndAttribute;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensor;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.test.Asserts;
 
-public class AttributeMungerTest {
+public class AttributeMungerTest extends BrooklynAppUnitTestSupport {
 
-    private TestApplication app;
     private List<Object> events;
     private Location loc;
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
+        super.setUp();
         events = Lists.newCopyOnWriteArrayList();
-        app = ApplicationBuilder.newManagedApp(TestApplication.class);
         loc = app.getManagementContext().getLocationManager().createLocation(LocationSpec.create(SimulatedLocation.class));
         app.start(ImmutableList.of(loc));
 

--- a/portforwarding/src/test/java/brooklyn/networking/portforwarding/AbstractDockerPortForwarderTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/portforwarding/AbstractDockerPortForwarderTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -36,7 +37,6 @@ import com.google.common.net.HostAndPort;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.location.access.PortForwardManager;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
@@ -47,7 +47,7 @@ import org.apache.brooklyn.util.net.Networking;
 
 // TODO Tests currently written to be fast: they assume existing VMs are configured.
 // Could re-write to create the VMs (and terminate them obviously) for each run.
-public abstract class AbstractDockerPortForwarderTest {
+public abstract class AbstractDockerPortForwarderTest extends BrooklynAppUnitTestSupport {
 
     private static final Logger log = LoggerFactory.getLogger(AbstractDockerPortForwarderTest.class);
 
@@ -113,7 +113,7 @@ public abstract class AbstractDockerPortForwarderTest {
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        app = ApplicationBuilder.newManagedApp(TestApplication.class, managementContext);
+        super.setUp();
         portForwarder = new DockerPortForwarder(portForwardManager);
         portForwarder.init(DOCKER_HOST_IP, DOCKER_HOST_PORT);
     }

--- a/portforwarding/src/test/java/brooklyn/networking/portforwarding/AbstractPortForwarderIptablesTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/portforwarding/AbstractPortForwarderIptablesTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.apache.brooklyn.api.entity.EntitySpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -38,7 +39,6 @@ import com.google.common.net.HostAndPort;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.location.access.PortForwardManager;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.jclouds.JcloudsLocation;
@@ -179,7 +179,7 @@ public abstract class AbstractPortForwarderIptablesTest {
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        app = ApplicationBuilder.newManagedApp(TestApplication.class, managementContext);
+        app = managementContext.getEntityManager().createEntity(EntitySpec.create(TestApplication.class));
     }
 
     @AfterMethod(alwaysRun=true)

--- a/portforwarding/src/test/java/brooklyn/networking/tunnelling/SshTunnellingIntegrationTest.java
+++ b/portforwarding/src/test/java/brooklyn/networking/tunnelling/SshTunnellingIntegrationTest.java
@@ -21,9 +21,9 @@ import static org.testng.Assert.assertTrue;
 import java.io.File;
 import java.util.Arrays;
 
+import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.reporters.Files;
@@ -32,36 +32,23 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.brooklyn.api.location.LocationSpec;
-import org.apache.brooklyn.api.mgmt.ManagementContext;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
-import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
 import org.apache.brooklyn.util.text.Identifiers;
 
-public class SshTunnellingIntegrationTest {
+public class SshTunnellingIntegrationTest extends BrooklynAppUnitTestSupport {
 
     private static final Logger log = LoggerFactory.getLogger(SshTunnellingIntegrationTest.class);
 
-    protected TestApplication app;
-    protected ManagementContext managementContext;
     protected SshMachineLocation localMachine;
 
     @BeforeMethod(alwaysRun=true)
     public void setUp() throws Exception {
-        app = ApplicationBuilder.newManagedApp(TestApplication.class);
-        managementContext = app.getManagementContext();
-
-        localMachine = managementContext.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+        super.setUp();
+        localMachine = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure("address", Networking.getLocalHost()));
-    }
-
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() throws Exception {
-        if (managementContext != null) Entities.destroyAll(managementContext);
     }
 
     // TODO This code checks if ~/.ssh/id_rsa already exists, and if it does then it's a no-op.
@@ -114,7 +101,7 @@ public class SshTunnellingIntegrationTest {
 
         SshTunnelling.authorizePublicKey(localMachine, publicKeyData);
 
-        SshMachineLocation viaForwarding = managementContext.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
+        SshMachineLocation viaForwarding = mgmt.getLocationManager().createLocation(LocationSpec.create(SshMachineLocation.class)
                 .configure("address", localMachine.getAddress())
                 .configure("port", localMachine.getPort())
                 .configure("user", localMachine.getUser())
@@ -123,7 +110,7 @@ public class SshTunnellingIntegrationTest {
             assertTrue(viaForwarding.isSshable(), "hostAndPort="+viaForwarding);
         } finally {
             viaForwarding.close();
-            managementContext.getLocationManager().unmanage(viaForwarding);
+            mgmt.getLocationManager().unmanage(viaForwarding);
             new File(privateKeyFile).delete();
             new File(publicKeyFile).delete();
         }


### PR DESCRIPTION
# What
Unit tests updated so that they no longer require the use of `org.apache.brooklyn.core.entity.factory.ApplicationBuilder`
* Where possible unit tests now extend `org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport`

# Why
`org.apache.brooklyn.core.entity.factory.ApplicationBuilder` was removed from the brooklyn codebase in https://github.com/apache/brooklyn-server/pull/738